### PR TITLE
Fix random sim fails, add assert messages

### DIFF
--- a/src/main/scala/vexiiriscv/execute/CsrAccessPlugin.scala
+++ b/src/main/scala/vexiiriscv/execute/CsrAccessPlugin.scala
@@ -154,7 +154,7 @@ class CsrAccessPlugin(layer : LaneLayer,
 
       val inject = new elp.Execute(injectAt){
 
-        assert(!(up(LANE_SEL) && SEL && hasCancelRequest))
+        assert(!(up(LANE_SEL) && SEL && hasCancelRequest), "CsrAccessPlugin saw forbidden select && cancel request")
         val imm = IMM(UOP)
         val immZero = imm.z === 0
         val srcZero = CSR_IMM ? immZero otherwise UOP(Const.rs1Range) === 0

--- a/src/main/scala/vexiiriscv/execute/LsuCachelessPlugin.scala
+++ b/src/main/scala/vexiiriscv/execute/LsuCachelessPlugin.scala
@@ -141,7 +141,7 @@ class LsuCachelessPlugin(var layer : LaneLayer,
       val tpk =  onAddress.translationPort.keys
       val MISS_ALIGNED = insert((1 to log2Up(LSLEN / 8)).map(i => SIZE === i && onAddress.RAW_ADDRESS(i - 1 downto 0) =/= 0).orR) //TODO remove from speculLoad and handle it with trap
       val RS2 = elp(IntRegFile, riscv.RS2)
-      assert(bus.cmd.ready) // For now
+      assert(bus.cmd.ready, "LsuCachelessPlugin expected bus.cmd.ready to be True, but False") // For now
 
 
       val cmdSent = RegInit(False) setWhen(bus.cmd.fire) clearWhen(isReady)
@@ -157,7 +157,7 @@ class LsuCachelessPlugin(var layer : LaneLayer,
       bus.cmd.mask := AddressToMask(bus.cmd.address, bus.cmd.size, Riscv.LSLEN/8)
       bus.cmd.io := tpk.IO
       bus.cmd.hartId := Global.HART_ID
-      assert(tpk.REDO === False)
+      assert(tpk.REDO === False, "LsuCachelessPlugin expected translation port REDO False, but True")
 
       elp.freezeWhen(bus.cmd.isStall)
 
@@ -174,7 +174,7 @@ class LsuCachelessPlugin(var layer : LaneLayer,
       val READ_DATA = insert(buffer.data)
       elp.freezeWhen(isValid && SEL && !buffer.valid)
       buffer.ready := isReady && SEL
-      assert(!(isValid && hasCancelRequest && SEL && !LOAD)) //TODO add tpk.IO and along the way
+      assert(!(isValid && hasCancelRequest && SEL && !LOAD), "LsuCachelessPlugin saw unexpected select && !LOAD && cancel request") //TODO add tpk.IO and along the way
     }
 
     val onWb = new wbCtrl.Area{

--- a/src/test/scala/vexiiriscv/tester/TestBench.scala
+++ b/src/test/scala/vexiiriscv/tester/TestBench.scala
@@ -201,6 +201,7 @@ class TestOptions{
     val lsclp = dut.host.get[execute.LsuCachelessPlugin].map { p =>
       val bus = p.logic.bus
       val cmdReady = StreamReadyRandomizer(bus.cmd, cd)
+      bus.cmd.ready #= true
 
       case class Access(write : Boolean, address: Long, data : Array[Byte], bytes : Int, io : Boolean)
       val pending = mutable.Queue[Access]()


### PR DESCRIPTION
StreamDriver does not drive the ready signal before the first clock edge, which can trigger the assertion in the LsuCachelessPlugin. Drive at simulation start to prevent that.

Add assert message to make it easier to debug regression fails caused by them.