### PR TITLE
MicroSoc: Fix typo in CLI options

### DIFF
--- a/src/main/scala/vexiiriscv/soc/micro/SocCtrl.scala
+++ b/src/main/scala/vexiiriscv/soc/micro/SocCtrl.scala
@@ -15,7 +15,7 @@ class SocCtrlParam {
     import parser._
     opt[Int]("system-frequency") action { (v, c) => systemFrequency = v Hz }
     opt[Boolean]("jtag-tap") action { (v, c) => withJtagTap = v  }
-    opt[Boolean]("tag-instruction") action { (v, c) => withJtagInstruction = v}
+    opt[Boolean]("jtag-instruction") action { (v, c) => withJtagInstruction = v}
   }
 }
 


### PR DESCRIPTION
Fixes a simple typo in the MicroSoc demo CLI options.

Everything points towards this being a typo including
https://github.com/SpinalHDL/VexiiRiscv/blob/98db3c6fbecd3f211e7ace5ee3e64276a4c9fb5f/src/main/scala/vexiiriscv/soc/litex/Soc.scala#L107