### PR TITLE
Add support Regfile with fewer than 32 registers (RV32E/RV64E)

### DIFF
--- a/src/main/scala/vexiiriscv/Param.scala
+++ b/src/main/scala/vexiiriscv/Param.scala
@@ -491,7 +491,8 @@ class ParamSimple() {
   // Generate a human redable name from most of the supported configuration
   def getName() : String = {
     def opt(that : Boolean, v : String) = that.mux(v, "")
-    var isa = s"rv${xlen}i"
+    var isa = s"rv${xlen}"
+    if (withRve) isa += "e" else isa += "i"
     if (withMul) isa += s"m"
     if (withRva) isa += "a"
     if (withRvf) isa += "f"

--- a/src/main/scala/vexiiriscv/Param.scala
+++ b/src/main/scala/vexiiriscv/Param.scala
@@ -123,6 +123,7 @@ class ParamSimple() {
   var withDiv = false
   var withRva = false
   var withRvf = false
+  var withRve = false
   var withRvcbm = false
   var withRvZknAes = true
   var gshareBanks = 1
@@ -561,6 +562,7 @@ class ParamSimple() {
     opt[Unit]("with-mul").unbounded() action { (v, c) => withMul = true }
     opt[Unit]("with-div").unbounded() action { (v, c) => withDiv = true }
     opt[Unit]("with-rvm") action { (v, c) => withMul = true; withDiv = true }
+    opt[Unit]("with-rve") action { (v, c) => withRve = true }
     opt[Unit]("with-rva") action { (v, c) => withRva = true }
     opt[Unit]("with-rvf") action { (v, c) => withRvf = true }
     opt[Unit]("with-rvd") action { (v, c) => withRvd = true; withRvf = true }
@@ -689,7 +691,7 @@ class ParamSimple() {
 
     val intWritebackAt = 2 //Alias for "trap at" as well
 
-    plugins += new riscv.RiscvPlugin(xlen, hartCount, rvf = withRvf, rvd = withRvd, rvc = withRvc)
+    plugins += new riscv.RiscvPlugin(xlen, hartCount, rvf = withRvf, rvd = withRvd, rvc = withRvc, rve = withRve)
     withMmu match {
       case false => plugins += new vexiiriscv.memory.StaticTranslationPlugin(physicalWidth)
       case true => plugins += new vexiiriscv.memory.MmuPlugin(
@@ -816,7 +818,7 @@ class ParamSimple() {
 
     plugins += new regfile.RegFilePlugin(
       spec = riscv.IntRegFile,
-      physicalDepth = 32,
+      physicalDepth = if(withRve) 16 else 32,
       preferedWritePortForInit = "lane0",
       syncRead = regFileSync,
       dualPortRam = regFileDualPortRam,

--- a/src/main/scala/vexiiriscv/decode/DecoderPlugin.scala
+++ b/src/main/scala/vexiiriscv/decode/DecoderPlugin.scala
@@ -85,7 +85,7 @@ class DecoderPlugin(var decodeAt : Int) extends FiberPlugin with DecoderService 
 
     val rfaKeys = mutable.LinkedHashMap[RfAccess, AccessKeys]()
     for(rfa <- rfAccesses){
-      val physWidth = 5
+      val physWidth = if(Riscv.RVE) 4 else 5
       val rfMapping = resources.collect{case r : RfResource /*if r.access == rfa*/ => r.rf }.toList //Commenting if r.access == rfa ensure all rfa mappings have the same RFID mapping
       val ak = AccessKeys(rfa, physWidth, rfMapping)
       ak.setPartialName(rfa)
@@ -169,7 +169,7 @@ class DecoderPlugin(var decodeAt : Int) extends FiberPlugin with DecoderService 
           case RS2 => riscv.Const.rs2Range
           case RS3 => riscv.Const.rs3Range
           case RD  => riscv.Const.rdRange
-        }).asUInt
+        }).asUInt(keys.physWidth-1 downto 0)
       }
 
       LEGAL := Symplify(Decode.INSTRUCTION, encodings.all) && !Decode.DECOMPRESSION_FAULT

--- a/src/main/scala/vexiiriscv/decode/DecoderPlugin.scala
+++ b/src/main/scala/vexiiriscv/decode/DecoderPlugin.scala
@@ -85,8 +85,8 @@ class DecoderPlugin(var decodeAt : Int) extends FiberPlugin with DecoderService 
 
     val rfaKeys = mutable.LinkedHashMap[RfAccess, AccessKeys]()
     for(rfa <- rfAccesses){
-      val physWidth = if(Riscv.RVE) 4 else 5
       val rfMapping = resources.collect{case r : RfResource /*if r.access == rfa*/ => r.rf }.toList //Commenting if r.access == rfa ensure all rfa mappings have the same RFID mapping
+      val physWidth = log2Up(rfMapping.map(_.sizeArch).max)
       val ak = AccessKeys(rfa, physWidth, rfMapping)
       ak.setPartialName(rfa)
       rfaKeys(rfa) = ak

--- a/src/main/scala/vexiiriscv/execute/ExecuteLanePlugin.scala
+++ b/src/main/scala/vexiiriscv/execute/ExecuteLanePlugin.scala
@@ -151,7 +151,7 @@ class ExecuteLanePlugin(override val laneName : String,
         val rfPlugin = host.find[RegfileService](_.rfSpec == spec.rf)
         val port = rfPlugin.newRead(false)
         port.valid := !eupp.isFreezed() // && readCtrl(rfa.ENABLE) && rfa.is(spec.rf, readCtrl(rfa.RFID))
-        port.address := readCtrl(rfa.PHYS)
+        port.address := readCtrl(rfa.PHYS)(log2Up(spec.rf.sizeArch) - 1 downto 0)
 
         // Generate a bypass specification for the regfile readed data
         case class BypassSpec(eu: ExecuteLaneService, nodeId: Int, payload: Payload[Bits])

--- a/src/main/scala/vexiiriscv/execute/WriteBackPlugin.scala
+++ b/src/main/scala/vexiiriscv/execute/WriteBackPlugin.scala
@@ -94,7 +94,7 @@ class WriteBackPlugin(val lane : ExecuteLaneService,
     val write = new writeCtrl.Area {
       val port = rfp.newWrite(false, sharingKey = laneName)
       port.valid := isValid && isReady && !isCancel && up(rfa.ENABLE) && SEL && Global.COMMIT
-      port.address := HART_ID @@ rfa.PHYS
+      port.address := HART_ID @@ rfa.PHYS(log2Up(rf.sizeArch) - 1 downto 0)
       port.data := DATA
       port.hartId := HART_ID
       port.uopId := UOP_ID

--- a/src/main/scala/vexiiriscv/riscv/Misc.scala
+++ b/src/main/scala/vexiiriscv/riscv/Misc.scala
@@ -8,11 +8,13 @@ object Riscv extends AreaObject {
   val XLEN = blocking[Int]
   val FLEN = blocking[Int]
   val LSLEN = blocking[Int]
-  val RVC, RVM, RVD, RVF, RVA, RVZba, RVZbb, RVZbc, RVZbs, RVZcbm = blocking[Boolean]
+  val RVC, RVM, RVE, RVD, RVF, RVA, RVZba, RVZbb, RVZbc, RVZbs, RVZcbm = blocking[Boolean]
   def withFpu = RVF || RVD
 
   def fpuExponentWidth = if (RVD) 11 else if (RVF) 8 else 0
   def fpuMantissaWidth = if (RVD) 52 else if (RVF) 23 else 0
+
+  def rfDepth = if (RVE) 16 else 32
 
   /**
    * This is a simple bootloader, which will initialize registers to match opensbi needs (a0 a1 a2).

--- a/src/main/scala/vexiiriscv/riscv/RegFile.scala
+++ b/src/main/scala/vexiiriscv/riscv/RegFile.scala
@@ -10,7 +10,7 @@ package vexiiriscv.riscv
 import spinal.core.{AreaObject, MaskedLiteral}
 
 object IntRegFile extends RegfileSpec with AreaObject {
-  override def sizeArch = 32
+  override def sizeArch = Riscv.rfDepth
   override def width = Riscv.XLEN
   override def x0AlwaysZero = true
   override def getName() = "integer"

--- a/src/main/scala/vexiiriscv/riscv/RiscvPlugin.scala
+++ b/src/main/scala/vexiiriscv/riscv/RiscvPlugin.scala
@@ -13,13 +13,15 @@ class RiscvPlugin(var xlen : Int,
                   var hartCount : Int,
                   var rvc: Boolean,
                   var rvf: Boolean,
-                  var rvd: Boolean) extends FiberPlugin {
+                  var rvd: Boolean,
+                  var rve: Boolean = false) extends FiberPlugin {
 
   val logic = during build new Area {
     if(Riscv.RVC.isEmpty) Riscv.RVC.set(rvc)
     if(Riscv.RVM.isEmpty) Riscv.RVM.set(false)
     if(Riscv.RVF.isEmpty) Riscv.RVF.set(rvf)
     if(Riscv.RVD.isEmpty) Riscv.RVD.set(rvd)
+    if(Riscv.RVE.isEmpty) Riscv.RVE.set(rve)
     if(Riscv.RVZba.isEmpty) Riscv.RVZba.set(false)
     if(Riscv.RVZbb.isEmpty) Riscv.RVZbb.set(false)
     if(Riscv.RVZbc.isEmpty) Riscv.RVZbc.set(false)


### PR DESCRIPTION
Described in #64. Adding option for RVE spec, which reduces integer regfile from 32 regs to 16 regs. Also allowing address widths passed to any type of regfiles to change according to their specs (`sizeArch`).