### PR TITLE
Introduce basic AIA support

### DIFF
--- a/src/main/scala/vexiiriscv/Param.scala
+++ b/src/main/scala/vexiiriscv/Param.scala
@@ -136,6 +136,7 @@ class ParamSimple() {
   var withRvd = false
   var withRvZb = false
   var withWhiteboxerOutputs = false
+  var withIndirectCsr = false
   var privParam = PrivilegedParam.base
   var lsuForkAt = 0
   var lsuPmaAt = 0
@@ -500,6 +501,7 @@ class ParamSimple() {
     if (withRvd) isa += "d"
     if (withRvc) isa += "c"
     if (withRvZb) isa += "ZbaZbbZbcZbs"
+    if (withIndirectCsr) isa += "Smcsrind" + privParam.withSupervisor.mux("Sscsrind", "")
     if (privParam.withSupervisor) isa += "s"
     if (privParam.withUser) isa += "u"
     val r = new ArrayBuffer[String]()
@@ -603,6 +605,7 @@ class ParamSimple() {
     opt[Unit]("regfile-infer-ports") action { (v, c) => regFileDualPortRam = false }
     opt[Unit]("regfile-reg-based") action { (v, c) => regFileRegBasedRam = true; regFileDualPortRam = false}
     opt[Int]("allow-bypass-from") action { (v, c) => allowBypassFrom = v }
+    opt[Unit]("with-indirect-csr") action { (v, c) => withIndirectCsr = true }
     opt[Int]("performance-counters").unbounded() action { (v, c) => withPerformanceCounters = true; additionalPerformanceCounters = v }
     opt[Unit]("without-performance-scountovf").unbounded() action { (v, c) => withPerformanceScountovf = false }
     opt[Unit]("with-fetch-l1").unbounded() action { (v, c) => fetchL1Enable = true }
@@ -990,6 +993,7 @@ class ParamSimple() {
     plugins += new CsrRamPlugin()
     if(withPerformanceCounters) plugins += new PerformanceCounterPlugin(additionalCounterCount = additionalPerformanceCounters)
     plugins += new CsrAccessPlugin(early0, writeBackKey =  if(lanes == 1) "lane0" else "lane1")
+    if(withIndirectCsr) plugins += new IndirectCsrPlugin(privParam.withSupervisor)
     plugins += new PrivilegedPlugin(privParam, withHartIdInput.mux(null, hartId until hartId+hartCount))
     plugins += new TrapPlugin(trapAt = intWritebackAt)
     plugins += new EnvPlugin(early0, executeAt = 0)

--- a/src/main/scala/vexiiriscv/execute/CsrService.scala
+++ b/src/main/scala/vexiiriscv/execute/CsrService.scala
@@ -23,6 +23,22 @@ case class CsrWriteCancel(override val csrFilter : Any, cond : Bool) extends Csr
 case class CsrOnReadData (bitOffset : Int, value : Bits)
 case class CsrIsReadingHartId(hartId : Int, value : Bool)
 
+/**
+ * CSR filter which ckecks both CSR id and runtime condition
+ *
+ * The CSR filter serves as an enhanced csr filter with extra runtime check.
+ * It is designed to simplify CSR with complex access requirement (such as
+ * indirect CSR), or CSR needs to be mapped to different register with
+ * different condition.
+ *
+ * For a single CsrCondFilter, it is equivalent to performing the following:
+ *
+ * Read:  `csr.read(id)  + csr.allowCSR(id, cond)`
+ * Write: `csr.write(id) + csr.allowCSR(id, cond)`
+ *
+ * For multiple CsrCondFilter with the same id, its `cond` should be exclusive,
+ * otherwise some unexpected behavior may occur.
+ */
 case class CsrCondFilter(csrId : Int, cond : Bool) extends CsrFilter
 case class CsrListFilter(mapping : scala.collection.Seq[Int]) extends CsrFilter
 

--- a/src/main/scala/vexiiriscv/misc/IndirectCsrPlugin.scala
+++ b/src/main/scala/vexiiriscv/misc/IndirectCsrPlugin.scala
@@ -1,0 +1,57 @@
+package vexiiriscv.misc
+
+import spinal.core.{Bool, _}
+import spinal.core.fiber.Retainer
+import spinal.lib._
+import spinal.lib.fsm._
+import spinal.lib.misc.pipeline.Payload
+import spinal.lib.misc.plugin.FiberPlugin
+import vexiiriscv.Global._
+import vexiiriscv.execute.{CsrAccessPlugin, CsrCondFilter, CsrListFilter, CsrRamPlugin, CsrRamService}
+import vexiiriscv.riscv._
+import vexiiriscv.riscv.Riscv._
+import vexiiriscv._
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+class IndirectCsrPlugin(val withSupervisor : Boolean) extends FiberPlugin {
+  val logic = during setup new Area {
+    val cap = host[CsrAccessPlugin]
+    val buildBefore = retains(cap.csrLock)
+
+    awaitBuild()
+
+    val harts = for (hartId <- 0 until HART_COUNT) yield new Area {
+      val api = cap.hart(hartId)
+
+      val m = new Area {
+        val iselect = RegInit(U(0, XLEN bits))
+        api.readWrite(iselect, CSR.MISELECT)
+
+        val iregs = for (i <- 0 until 6) yield (i + CSR.MIREG)
+
+        def csrFilter(indirectId: Int, targetCsr: Int, cond: Bool = True): CsrCondFilter = {
+          assert(iregs.contains(targetCsr), s"${targetCsr} is not an indirect CSR alias")
+
+          CsrCondFilter(targetCsr, (iselect === indirectId) && cond)
+        }
+      }
+
+      val s = withSupervisor generate new Area {
+        val iselect = RegInit(U(0, XLEN bits))
+        api.readWrite(iselect, CSR.SISELECT)
+
+        val iregs = for (i <- 0 until 6) yield (i + CSR.SIREG)
+
+        def csrFilter(indirectId: Int, targetCsr: Int, cond: Bool = True): CsrCondFilter = {
+          assert(iregs.contains(targetCsr), s"${targetCsr} is not an indirect CSR alias")
+
+          CsrCondFilter(targetCsr, (iselect === indirectId) && cond)
+        }
+      }
+    }
+
+    buildBefore.release()
+  }
+}

--- a/src/main/scala/vexiiriscv/misc/PrivilegedPlugin.scala
+++ b/src/main/scala/vexiiriscv/misc/PrivilegedPlugin.scala
@@ -616,6 +616,12 @@ class PrivilegedPlugin(val p : PrivilegedParam, val hartIds : Seq[Int]) extends 
         spec.addInterrupt(ip.mtip && ie.mtie, id = 7, privilege = 3, delegators = Nil)
         spec.addInterrupt(ip.msip && ie.msie, id = 3, privilege = 3, delegators = Nil)
         spec.addInterrupt(ip.meip && ie.meie, id = 11, privilege = 3, delegators = Nil)
+
+        val topi = new Area {
+          val interrupt = Global.CODE().assignDontCare()
+          val priority = Mux(interrupt === B(0), B(0), B(1))
+          api.read(CSR.MTOPI, 0 -> priority, 16 -> interrupt)
+        }
       }
 
       val mcounteren = p.withRdTime generate new Area {
@@ -726,6 +732,12 @@ class PrivilegedPlugin(val p : PrivilegedParam, val hartIds : Seq[Int]) extends 
         spec.addInterrupt(ip.seipOr && ie.seie, id = 9, privilege = 1, delegators = List(Delegator(m.ideleg.se, 3)))
 
         for ((id, enable) <- m.edeleg.mapping) spec.exception += ExceptionSpec(id, List(Delegator(enable, 3)))
+
+        val topi = new Area {
+          val interrupt = Global.CODE().assignDontCare()
+          val priority = Mux(interrupt === B(0), B(0), B(1))
+          api.read(CSR.STOPI, 0 -> priority, 16 -> interrupt)
+        }
       }
 
       val time = p.withRdTime generate new Area {

--- a/src/main/scala/vexiiriscv/misc/TrapPlugin.scala
+++ b/src/main/scala/vexiiriscv/misc/TrapPlugin.scala
@@ -225,6 +225,17 @@ class TrapPlugin(val trapAt : Int) extends FiberPlugin with TrapService {
 
         val privilegeIndexedTriggers = privilegs.zip(privilegeTriggers)
 
+        /* Link xTOPI register */
+        val xtopi = privilegeIndexedTriggers.map{case (p, i) => new Area {
+          val triggered = i.triggered
+          val int = B(triggered.id).andMask(triggered.valid).resized
+
+          p match {
+            case 3 => csr.m.topi.interrupt := int
+            case 1 => csr.s.topi.interrupt := int
+          }
+        }}
+
         val result = privilegeIndexedTriggers.map{case (p, i) => {
           val int = InterruptState(CODE_WIDTH)
           val triggered = i.triggered

--- a/src/main/scala/vexiiriscv/riscv/Const.scala
+++ b/src/main/scala/vexiiriscv/riscv/Const.scala
@@ -94,6 +94,13 @@ object CSR {
   def MCAUSE    = 0x342 // MRW Machine trap cause.
   def MTVAL     = 0x343 // MRW Machine bad address.
   def MIP       = 0x344 // MRW Machine interrupt pending.
+  def MISELECT  = 0x350 // MRW Machine indirect register select.
+  def MIREG     = 0x351 // MRW Machine indirect register alias.
+  def MIREG2    = 0x352 // MRW Machine indirect register alias 2.
+  def MIREG3    = 0x353 // MRW Machine indirect register alias 3.
+  def MIREG4    = 0x354 // MRW Machine indirect register alias 4.
+  def MIREG5    = 0x355 // MRW Machine indirect register alias 5.
+  def MIREG6    = 0x356 // MRW Machine indirect register alias 6.
   def MENVCFG   = 0x30A // MRW Machine environment configuration register.
   def MENVCFGH  = 0x31A // MRW Machine environment configuration register.
   def MBASE     = 0x380 // MRW Base register.
@@ -129,6 +136,13 @@ object CSR {
   val STVAL       = 0x143
   val SIP         = 0x144
   val STIMECMP    = 0x14D
+  val SISELECT    = 0x150
+  val SIREG       = 0x151
+  val SIREG2      = 0x152
+  val SIREG3      = 0x153
+  val SIREG4      = 0x154
+  val SIREG5      = 0x155
+  val SIREG6      = 0x156
   val STIMECMPH   = 0x15D
   val SATP        = 0x180
   val SCOUNTOVF   = 0xDA0

--- a/src/main/scala/vexiiriscv/riscv/Const.scala
+++ b/src/main/scala/vexiiriscv/riscv/Const.scala
@@ -122,6 +122,7 @@ object CSR {
   val MCOUNTEREN  = 0x306
   val MCOUNTINHIBIT = 0x320
   def MHPMEVENT0H = 0x720 // MRW Machine instructions-retired counter.
+  def MTOPI     = 0xFB0 // MRO Machine top interrupt.
 
   val PMPCFG = 0x3a0
   val PMPADDR = 0x3b0
@@ -146,6 +147,7 @@ object CSR {
   val STIMECMPH   = 0x15D
   val SATP        = 0x180
   val SCOUNTOVF   = 0xDA0
+  val STOPI       = 0xDB0
 
   def UCYCLE   = 0xC00 // UR Machine ucycle counter.
   def UCYCLEH  = 0xC80


### PR DESCRIPTION
The ISA part of the RISC-V AIA includes three things:
1. Indirect CSR support (`Smcsrind`, `Sscsrind`).
2. `xTOPI` CSR (`MTOPI`, `STOPI`)
3. Interrupt filter

This PR includes the first two things. The interrupt filter requires some hard change for `PrivilegedPlugin` and I am still trying to figure it out. However, this PR is enough for almost all the case, as the interrupt filter is not used at least for now (For OpenSBI and Linux). only `xTOPI` CSR is required.

Also, As the  `xTOPI` CSR just exports the information from PR #74, no new option is introduced to mask this CSR.