### PR TITLE
Add APLIC and IMSIC device support

### DIFF
--- a/src/main/scala/vexiiriscv/Param.scala
+++ b/src/main/scala/vexiiriscv/Param.scala
@@ -586,6 +586,7 @@ class ParamSimple() {
     opt[Unit]("with-rvZcbm") action { (v, c) => withRvcbm = true }
     opt[Unit]("with-rvZcbm-llc") action { (v, c) => withRvcbm = true; withRvcbmLlc = true }
     opt[Unit]("with-rvZknAes") action { (v, c) => withRvZknAes = true }
+    opt[Int]("imsic-interrupt-number") action { (v, c) => withIndirectCsr = true; privParam.imsicInterrupts = v }
     opt[Unit]("with-whiteboxer-outputs") action { (v, c) => withWhiteboxerOutputs = true }
     opt[Unit]("with-hart-id-input") action { (v, c) => withHartIdInput = true }
     opt[Unit]("with-hart-id-input-defaulted") action { (v, c) => privParam.withHartIdInputDefaulted = true }
@@ -1239,5 +1240,3 @@ lane micro op spec
   - mayFlushUpTo
   - dontFlushFrom
  */
-
-

--- a/src/main/scala/vexiiriscv/execute/CsrService.scala
+++ b/src/main/scala/vexiiriscv/execute/CsrService.scala
@@ -202,6 +202,10 @@ class CsrHartApi(csrService: CsrService, hartId : Int){
     }
   }
 
+  def onRead(csrFilter : Any, onlyOnFire : Boolean)(body : => Unit) = csrService.onRead(csrFilter, onlyOnFire){
+    when(csrService.writingHartId(hartId)){ body }
+  }
+
   def onWrite(csrFilter : Any, onlyOnFire : Boolean)(body : => Unit) = csrService.onWrite(csrFilter, onlyOnFire){
     when(csrService.writingHartId(hartId)){ body }
   }

--- a/src/main/scala/vexiiriscv/riscv/Const.scala
+++ b/src/main/scala/vexiiriscv/riscv/Const.scala
@@ -101,6 +101,7 @@ object CSR {
   def MIREG4    = 0x354 // MRW Machine indirect register alias 4.
   def MIREG5    = 0x355 // MRW Machine indirect register alias 5.
   def MIREG6    = 0x356 // MRW Machine indirect register alias 6.
+  def MTOPEI    = 0x35C // MRW Machine top external interrupt.
   def MENVCFG   = 0x30A // MRW Machine environment configuration register.
   def MENVCFGH  = 0x31A // MRW Machine environment configuration register.
   def MBASE     = 0x380 // MRW Base register.
@@ -144,6 +145,7 @@ object CSR {
   val SIREG4      = 0x154
   val SIREG5      = 0x155
   val SIREG6      = 0x156
+  val STOPEI      = 0x15C
   val STIMECMPH   = 0x15D
   val SATP        = 0x180
   val SCOUNTOVF   = 0xDA0
@@ -188,4 +190,11 @@ object InterruptInfo {
     10, 2, 6,   // VS interrupts: external, software, timer
     13          // Local interrupt: counter overflow
   )
+}
+
+object IndirectCSR{
+  val eidelivery  = 0x70
+  val eithreshold = 0x72
+  val eip0        = 0x80
+  val eie0        = 0xC0
 }

--- a/src/main/scala/vexiiriscv/soc/TilelinkVexiiRiscvFiber.scala
+++ b/src/main/scala/vexiiriscv/soc/TilelinkVexiiRiscvFiber.scala
@@ -9,6 +9,7 @@ import spinal.lib.{DataCc, StreamCCByToggle}
 import spinal.lib.bus.tilelink.fabric._
 import spinal.lib.cpu.riscv.RiscvHart
 import spinal.lib.cpu.riscv.debug.DebugHartBus
+import spinal.lib.misc.aia._
 import spinal.lib.misc.InterruptCtrlFiber
 import spinal.lib.misc.plugin.Hostable
 import spinal.lib.misc.{ClintPort, Elf, InterruptCtrl, InterruptNode, TilelinkClintFiber}
@@ -72,6 +73,16 @@ class TilelinkVexiiRiscvFiber(val plugins : ArrayBuffer[Hostable]) extends Area 
     }
   }
 
+  def bind(aplic: TilelinkAPlicFiber) = priv match {
+    case Some(priv) => new Area {
+      val pp = priv.plugin
+      val intIdBase = pp.hartIds(0)
+      aplic.domainParam.isMDomain match {
+        case true => aplic.mapDownInterrupt(intIdBase, priv.mei)
+        case false => aplic.mapDownInterrupt(intIdBase, priv.sei)
+      }
+    }
+  }
 
   // Add the plugins to bridge the CPU toward Tilelink
   plugins.foreach {

--- a/src/main/scala/vexiiriscv/soc/litex/Soc.scala
+++ b/src/main/scala/vexiiriscv/soc/litex/Soc.scala
@@ -23,9 +23,11 @@ import spinal.lib.cpu.riscv.debug.{DebugModuleFiber, DebugModuleSocFiber}
 import spinal.lib.eda.bench.{Bench, Rtl}
 import spinal.lib.graphic.YcbcrConfig
 import spinal.lib.graphic.vga.{TilelinkVgaCtrlFiber, TilelinkVgaCtrlSpec, Vga, VgaRgbToYcbcr, VgaYcbcrPix2}
+import spinal.lib.misc.aia._
 import spinal.lib.misc.{Elf, PathTracer, TilelinkClintFiber}
 import spinal.lib.misc.plic.TilelinkPlicFiber
 import spinal.lib.misc.test.DualSimTracer
+import spinal.lib.misc.{InterruptNode, InterruptCtrlFiber}
 import spinal.lib.sim.SparseMemory
 import spinal.lib.{AnalysisUtils, Delay, Flow, ResetCtrlFiber, StreamPipe, master, memPimped, slave, traversableOncePimped}
 import spinal.lib.system.tag.{MemoryConnection, MemoryEndpoint, MemoryEndpointTag, MemoryTransferTag, MemoryTransfers, PMA, VirtualEndpoint}
@@ -86,6 +88,7 @@ class SocConfig(){
   val video = ArrayBuffer[TilelinkVgaCtrlSpec]()
   val macSg = ArrayBuffer[MacSgFiberSpec]()
   var withCpuCd = false
+  var withAPlic = false
 
   def addOptions(parser: scopt.OptionParser[Unit]): Unit = {
     import parser._
@@ -106,6 +109,7 @@ class SocConfig(){
     opt[Unit]("with-jtag-tap") action { (v, c) => withJtagTap = true; vexiiParam.privParam.withDebug = true }
     opt[Unit]("with-jtag-instruction") action { (v, c) => withJtagInstruction = true; vexiiParam.privParam.withDebug = true }
     opt[Unit]("with-debug-probe-pc0") text("Allows to profile the CPU via JTAG. See ElfMapper.") action { (v, c) => withDebugProbePc0 = true }
+    opt[Unit]("with-aplic") action { (v, c) => withAPlic = true }
 
     opt[Seq[String]]("memory-region").unbounded() action { (v, c) =>
       assert(v.length == 4, "--memory-region need 4 parameters")
@@ -162,6 +166,7 @@ class Soc(c : SocConfig) extends Component {
   val system = cpuCd on new AreaRoot {
     val mainDataWidth = vexiiParam.memDataWidth
     val withCoherency = vexiiParam.lsuL1Coherency
+    val withSupervisor = vexiiParam.privParam.withSupervisor
     val vexiis = for (hartId <- 0 until cpuCount) yield new TilelinkVexiiRiscvFiber(vexiiParam.plugins(hartId))
     for (vexii <- vexiis) {
       if (vexiiParam.fetchL1Enable) vexii.iBus.setDownConnection { (down, up) =>
@@ -230,24 +235,55 @@ class Soc(c : SocConfig) extends Component {
       val clint = new TilelinkClintFiber()
       clint.node at 0xF0010000l of bus
 
-      val plic = new TilelinkPlicFiber()
-      plic.node at 0xF0C00000l of bus
+      for (vexii <- vexiis) {
+        vexii.bind(clint)
+      }
 
+      val aplic = withAPlic generate new Area {
+        val m = new Area {
+          val intc = new TilelinkAPlicFiber(APlicDomainParam.root(APlicGenParam.direct))
+          intc.node at 0xF0C00000l of bus
+
+          for (vexii <- vexiis) {
+            vexii.bind(intc)
+          }
+        }
+
+        val s = withSupervisor generate new Area {
+          val intc = new TilelinkAPlicFiber(APlicDomainParam.S(APlicGenParam.direct))
+          intc.node at 0xF0E00000l of bus
+
+          m.intc.addChildCtrl(intc)
+
+          intc.mmsiaddrcfg := m.intc.mmsiaddrcfg
+          intc.smsiaddrcfg := m.intc.smsiaddrcfg
+
+          for (vexii <- vexiis) {
+            vexii.bind(intc)
+          }
+        }
+      }
+
+      val plic = !withAPlic generate new Area {
+        val intc = new TilelinkPlicFiber()
+        intc.node at 0xF0C00000l of bus
+
+        for (vexii <- vexiis) {
+          vexii.bind(intc)
+        }
+      }
+
+      val intc: InterruptCtrlFiber = if (withAPlic) aplic.m.intc else plic.intc
       val externalInterrupts = new Area {
         val port = in Bits (32 bits)
         val toPlic = for (i <- 0 to 31) yield (i != 0) generate new Area {
-          val node = plic.createInterruptSlave(i)
+          val node = intc.createInterruptSlave(i)
           node.withUps = false
           node.flag := port(i)
         }
       }
 
-      val fromArgs = new PeriphTilelinkFiber(periph, bus, plic)
-
-      for (vexii <- vexiis) {
-        vexii.bind(clint)
-        vexii.bind(plic)
-      }
+      val fromArgs = new PeriphTilelinkFiber(periph, bus, intc)
 
       val toAxiLite4 = new fabric.AxiLite4Bridge
       toAxiLite4.up << bus
@@ -319,8 +355,10 @@ class Soc(c : SocConfig) extends Component {
         rxCd = rxResetCtrl.cd
       )
       fiber.ctrl at spec.ctrlAddress of ioBus
-      peripheral.plic.mapUpInterrupt(spec.txInterruptId, fiber.txInterrupt)
-      peripheral.plic.mapUpInterrupt(spec.rxInterruptId, fiber.rxInterrupt)
+
+      peripheral.intc.mapUpInterrupt(spec.txInterruptId, fiber.txInterrupt)
+      peripheral.intc.mapUpInterrupt(spec.rxInterruptId, fiber.rxInterrupt)
+
       dmaFilter.up << fiber.txMem
       dmaFilter.up << fiber.rxMem
       dmaFilter.down.setDownConnection(a = StreamPipe.M2S, d = StreamPipe.M2S)


### PR DESCRIPTION
Add APlic and Imsic generated based on "with-aplic" and "imsic-interrupt-number". 
## APlic
Add parameter conditions to generate aplac or plic.

## genImsicArea
Add CSRs to make "MSI delivery mode" worked. 
Add an arbiter to choose between using the line interrupt or MSI interrupt to notify hart.

## Imsic
Add Imsic support when "imsic-interrupt-number" not zero.