### PR TITLE
Fix --debug-jtag-tap missing privParam.withDebug

### DIFF
--- a/src/main/scala/vexiiriscv/Param.scala
+++ b/src/main/scala/vexiiriscv/Param.scala
@@ -664,8 +664,8 @@ class ParamSimple() {
     opt[Unit]("debug-privileged") action { (v, c) => privParam.withDebug = true }
     opt[Int] ("debug-triggers") action { (v, c) => privParam.debugTriggers = v }
     opt[Unit]("debug-triggers-lsu") action { (v, c) => privParam.debugTriggersLsu = true }
-    opt[Unit]("debug-jtag-tap") action { (v, c) => embeddedJtagTap = true }
-    opt[Unit]("debug-jtag-instruction") action { (v, c) => embeddedJtagInstruction = true }
+    opt[Unit]("debug-jtag-tap") action { (v, c) => embeddedJtagTap = true; privParam.withDebug = true }
+    opt[Unit]("debug-jtag-instruction") action { (v, c) => embeddedJtagInstruction = true; privParam.withDebug = true }
     opt[Unit]("with-boot-mem-init") action { (v, c) => bootMemClear = true }
     opt[Int]("physical-width") action { (v, c) => physicalWidth = v }
     opt[Unit]("mul-keep-src") action { (v, c) => mulKeepSrc = true }


### PR DESCRIPTION
Fixes #104

`--debug-jtag-tap` and `--debug-jtag-instruction` now set `privParam.withDebug = true`, matching the behavior in `Soc.scala` for `--with-jtag-tap`.

Without this, using `--debug-jtag-tap` alone causes a NullPointerException because `EmbeddedRiscvJtag` expects the privileged debug infrastructure to exist.