### PR TITLE
Move TLB permission check from LSU to MMU

### DIFF
--- a/src/main/scala/vexiiriscv/execute/lsu/LsuCachelessPlugin.scala
+++ b/src/main/scala/vexiiriscv/execute/lsu/LsuCachelessPlugin.scala
@@ -277,7 +277,7 @@ class LsuCachelessPlugin(var layer : LaneLayer,
         trapPort.code(1) setWhen (STORE)
       }
 
-      when(tpk.PAGE_FAULT || STORE.mux( !tpk.ALLOW_WRITE, !tpk.ALLOW_READ)) {
+      when(tpk.PAGE_FAULT) {
         skip := True
         trapPort.exception := True
         trapPort.code := CSR.MCAUSE_ENUM.LOAD_PAGE_FAULT

--- a/src/main/scala/vexiiriscv/execute/lsu/LsuPlugin.scala
+++ b/src/main/scala/vexiiriscv/execute/lsu/LsuPlugin.scala
@@ -588,7 +588,7 @@ class LsuPlugin(var layer : LaneLayer,
       val IO = insert(CACHED_RSP.fault && !IO_RSP.fault && !FENCE && !FROM_PREFETCH)
       val addressExtension = ats.getSignExtension(AddressTranslationPortUsage.LOAD_STORE, srcp.ADD_SUB.asUInt)
       val FROM_LSU_MSB_FAILED = insert(FROM_LSU && srcp.ADD_SUB.dropLow(Global.MIXED_WIDTH).asBools.map(_ =/= addressExtension).orR)
-      MMU_PAGE_FAULT := tpk.PAGE_FAULT || STORE.mux(!tpk.ALLOW_WRITE, !tpk.ALLOW_READ)
+      MMU_PAGE_FAULT := tpk.PAGE_FAULT
       MMU_FAILURE := MMU_PAGE_FAULT || tpk.ACCESS_FAULT || tpk.REFILL || tpk.HAZARD || FROM_LSU_MSB_FAILED
     }
 

--- a/src/main/scala/vexiiriscv/fetch/FetchCachelessPlugin.scala
+++ b/src/main/scala/vexiiriscv/fetch/FetchCachelessPlugin.scala
@@ -187,7 +187,7 @@ class FetchCachelessPlugin(var wordWidth : Int,
         trapPort.code := CSR.MCAUSE_ENUM.INSTRUCTION_ACCESS_FAULT
       }
 
-      when(tpk.PAGE_FAULT || !tpk.ALLOW_EXECUTE) {
+      when(tpk.PAGE_FAULT) {
         TRAP := True
         trapPort.exception := True
         trapPort.code := CSR.MCAUSE_ENUM.INSTRUCTION_PAGE_FAULT

--- a/src/main/scala/vexiiriscv/fetch/FetchL1Plugin.scala
+++ b/src/main/scala/vexiiriscv/fetch/FetchL1Plugin.scala
@@ -491,7 +491,7 @@ class FetchL1Plugin(var translationStorageParameter: Any,
         trapPort.code := CSR.MCAUSE_ENUM.INSTRUCTION_ACCESS_FAULT
       }
 
-      when(tpk.PAGE_FAULT || !tpk.ALLOW_EXECUTE) {
+      when(tpk.PAGE_FAULT) {
         allowRefill := False
         trapPort.valid := True
         trapPort.exception := True

--- a/src/main/scala/vexiiriscv/memory/Service.scala
+++ b/src/main/scala/vexiiriscv/memory/Service.scala
@@ -114,7 +114,6 @@ class AddressTranslationRsp(s : AddressTranslationService, val wayCount : Int) e
     val TRANSLATED = Payload(PHYSICAL_ADDRESS)
     val HAZARD = Payload(Bool())
     val REFILL = Payload(Bool())
-    val ALLOW_READ, ALLOW_WRITE, ALLOW_EXECUTE = Payload(Bool())
     val PAGE_FAULT = Payload(Bool())
     val ACCESS_FAULT = Payload(Bool())
     val WAYS_OH  = Payload(Bits(wayCount bits))

--- a/src/main/scala/vexiiriscv/memory/StaticTranslationPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/StaticTranslationPlugin.scala
@@ -65,9 +65,6 @@ class StaticTranslationPlugin(var physicalWidth: Int) extends FiberPlugin with A
       REFILL := False
       HAZARD := False
       TRANSLATED := spec.req.PRE_ADDRESS.resized //PC RESIZED
-      ALLOW_EXECUTE := True
-      ALLOW_READ := True
-      ALLOW_WRITE := True
       PAGE_FAULT := False
       ACCESS_FAULT := spec.req.PRE_ADDRESS.drop(physicalWidth) =/= 0
       BYPASS_TRANSLATION := True


### PR DESCRIPTION
This PR includes two changes:
1. Convert the newTranslationPort input payload as a separate for easy expansion.
2. Move TLB permission check from LSU to MMU.

The second change can be used a mask for the permission check, as only  `PAGE_FAULT`/`ACCESS_FAULT` are exposed, which will reduced the change when the guest-page permission is recorded.