### PR TITLE
Fix ParamSimple.hashCode() for withISA Set fields

### DIFF
--- a/src/main/scala/vexiiriscv/Param.scala
+++ b/src/main/scala/vexiiriscv/Param.scala
@@ -458,6 +458,7 @@ class ParamSimple() {
         case e: BigInt => md ++= s" $e"
         case e: String => md ++= s" $e"
         case e : Product => md ++= s" $e"
+        case e: Set[_] => md ++= s" ${e.map(_.toString).toSeq.sorted.mkString(" ")}"
         case e => {
           if(e.getClass.getName == "scala.Enumeration$Val"){
             md ++= s" ${e.toString}"


### PR DESCRIPTION
The commit ed47b19782edc8ea37e350536d7b88c277de1152 ("Add initial ISA map support for generator")
introduced the `withISA` field as a Set[String] in ParamSimple. 

When running the `RegressionSingle` test, it was observed that the existing
hashCode() implementation did not handle Set fields, which caused crashes or
unstable hash values when computing hashes for different ISA configurations.

This PR updates ParamSimple.hashCode() to add a dedicated case for Set[_] 
fields. The set elements are converted to strings and sorted before being
concatenated, ensuring a stable and unique hash across runs.