### PR TITLE
enable rs3 for the IntRegFile

### DIFF
--- a/src/main/scala/vexiiriscv/riscv/RegFile.scala
+++ b/src/main/scala/vexiiriscv/riscv/RegFile.scala
@@ -20,6 +20,10 @@ object IntRegFile extends RegfileSpec with AreaObject {
     key = key,
     resources = List(RS1, RS2, RD).map(this -> _)
   )
+  def TypeR3(key : MaskedLiteral) = SingleDecoding(
+    key = key,
+    resources = List(RS1, RS2, RS3, RD).map(this -> _)
+  )
   def TypeI(key : MaskedLiteral) = SingleDecoding(
     key = key,
     resources = List(RS1, RD).map(this -> _)


### PR DESCRIPTION
I am working on custom extensions and would like to add one that also has a third integer source register (similar to the `fmadd` instruction).
Is this something one could upstream as this doesn't change the generated core as far as I know and only opens the possibility to create instructions with 3 integer source registers.