### PR TITLE
fix: GenerateTilelink failed without --with-supervisor

### DIFF
--- a/src/main/scala/vexiiriscv/Generate.scala
+++ b/src/main/scala/vexiiriscv/Generate.scala
@@ -117,7 +117,7 @@ object GenerateTilelink extends App {
       cpu.priv.get.mei << mei; in(mei.flag)
 
       val sei = (cpu.priv.get.sei != null) generate InterruptNode.master()
-      if(sei != null) cpu.priv.get.sei << sei; in(sei.flag)
+      if(sei != null) { cpu.priv.get.sei << sei; in(sei.flag) }
 
       (cpu.priv.get.rdtime != null) generate in(cpu.priv.get.rdtime)
 


### PR DESCRIPTION
The missed `{}` of the original code forces the presence of `sei`. This can cause a `NullPointerException` during elaborations without `--with-supervisor` flag supplied.