### PR TITLE
Add bit manip extensions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ VexiiRiscv (Vex2Risc5) is the successor of VexRiscv. Work in progress, here are 
 - Pipeline visualisation in simulation via Konata
 - Lock step simulation via RVLS and Spike
 - AXI4, Wishbone, Tilelink memory busses (RVA is not available in some configs, see the RTD doc SoC main page)
+- Bit manipulation extensions [Zba][Zbb][Zbc][Zbs]
 - ... and many other things
 
 Here is a demonstration of a quad core VexiiRiscv running debian on FPGA : https://youtu.be/dR_jqS13D2c?t=112


### PR DESCRIPTION
This fix #140.

I did some test with generating a simple, very minimal MCU setup (no peripherial, nothing) with random zb* and it did generate verilog with a lot of combinations. My code look like this:


```
  val allIsaList = Seq("m", "d", "zicsr", "zifencei", "zba", "zbb", "zbc", "zbs")
  val rand = new scala.util.Random(345)

  for (_ <- 0 to 100) {
    val isaList = scala.collection.mutable.Set[String]()
    for (isa <- allIsaList) {
      if (rand.nextBoolean())
        isaList += isa
    }
```

It was successful with xlen=32 and xlen=64.

Note that if I use "f" instead of "d" in the list, it crash when "f" is activated in these kind of cases:

```
i + Set(f, zbb, zicsr, zbc, zbs)
i + Set(f)
i + Set(f, zba, zbs)
i + Set(f, zbb, zicsr, zbc, zba, zbs)
i + Set(f, zbb, zbc, zbs)
i + Set(f, zifencei, zbc)
```

with the callstack:
```
failed with extension i + Set(f, zbb, zicsr)
Exception in thread "main" java.lang.Exception: Can't find the service vexiiriscv.execute.RsUnsignedPlugin
        at spinal.lib.misc.plugin.PluginHost.apply(Host.scala:54)
        at vexiiriscv.execute.fpu.FpuUnpackerPlugin$$anon$1.<init>(FpuUnpackerPlugin.scala:58)
        at vexiiriscv.execute.fpu.FpuUnpackerPlugin.$anonfun$logic$1(FpuUnpackerPlugin.scala:56)
        at spinal.lib.misc.plugin.FiberPlugin$$anon$1.$anonfun$setup$4(Fiber.scala:74)
        at spinal.core.ScopeProperty$ApplyClass.apply(ScopeProperty.scala:144)
        at spinal.lib.misc.plugin.PluginHost.rework(Host.scala:29)
        at spinal.lib.misc.plugin.FiberPlugin$$anon$1.$anonfun$setup$2(Fiber.scala:72)
        at spinal.core.internals.BooleanPimped.generate(Misc.scala:285)
        at spinal.lib.misc.plugin.FiberPlugin$$anon$1.$anonfun$setup$1(Fiber.scala:69)
        at spinal.core.fiber.Fiber.$anonfun$addTask$1(Fiber.scala:74)
        at spinal.core.fiber.package$.$anonfun$hardForkRawHandle$1(package.scala:30)
        at spinal.core.fiber.AsyncThread.$anonfun$jvmThread$1(AsyncThread.scala:60)
        at spinal.core.fiber.EngineContext.$anonfun$newJvmThread$1(AsyncCtrl.scala:39)
```