### PR TITLE
VexiiRiscvProbe: defer trap dispatch until late-completing uops are reported

### DIFF
--- a/src/main/scala/vexiiriscv/test/VexiiRiscvProbe.scala
+++ b/src/main/scala/vexiiriscv/test/VexiiRiscvProbe.scala
@@ -197,6 +197,7 @@ class VexiiRiscvProbe(cpu : VexiiRiscv, kb : Option[konata.Backend], var withRvl
 
     var commits = 0l
 
+    val pendingTraps = mutable.Queue[(Boolean, Int, Int)]()
 
     val jbStats = mutable.HashMap[Long, JbStats]()
     val branchStats = new JbStats()
@@ -590,6 +591,13 @@ class VexiiRiscvProbe(cpu : VexiiRiscv, kb : Option[konata.Backend], var withRvl
         simFailure(f"Vexii hasn't committed anything for too long, $status")
       }
 
+      def flushDueTraps(): Unit = {
+        while (hart.pendingTraps.nonEmpty && hart.pendingTraps.head._3 == hart.microOpRetirePtr) {
+          val (interrupt, cause, _) = hart.pendingTraps.dequeue()
+          backends.foreach(_.trap(hart.hartId, interrupt, cause))
+        }
+      }
+      flushDueTraps()
       while (hart.microOpRetirePtr != hart.microOpAllocPtr && hart.microOp(hart.microOpRetirePtr).done) {
         import hart._
         val uopId = hart.microOpRetirePtr
@@ -636,6 +644,7 @@ class VexiiRiscvProbe(cpu : VexiiRiscv, kb : Option[konata.Backend], var withRvl
           uop.clear()
         }
         hart.microOpRetirePtr = (hart.microOpRetirePtr + 1) & microOpIdMask
+        flushDueTraps()
       }
     }
   }
@@ -652,7 +661,12 @@ class VexiiRiscvProbe(cpu : VexiiRiscv, kb : Option[konata.Backend], var withRvl
 
   def checkTraps(): Unit = {
     for(trap <- proxies.trap) if(trap.fire.toBoolean){
-      backends.foreach(_.trap(hartsIds(trap.hartId), trap.interrupt.toBoolean, trap.cause.toInt))
+      val hart = harts(trap.hartId)
+      if (hart.microOpRetirePtr == hart.microOpAllocPtr && hart.pendingTraps.isEmpty) {
+        backends.foreach(_.trap(hartsIds(trap.hartId), trap.interrupt.toBoolean, trap.cause.toInt))
+      } else {
+        hart.pendingTraps.enqueue((trap.interrupt.toBoolean, trap.cause.toInt, hart.microOpAllocPtr))
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #146

`checkTraps()` dispatched a trap to the co-sim backends the moment the trap FSM fired, even when an older, in-order-committed uop (e.g. an FPU op with a late writeback) had not yet been reported through `checkCommits()`. RVLS then observed the trap one instruction early and aborted with a false `DUT did trap on <pc>`, although the RTL behavior (including `mepc`) was architecturally correct.

This PR queues such a trap together with a snapshot of `microOpAllocPtr`, and dispatches it from the retire stream once `microOpRetirePtr` reaches that snapshot, so the backends observe commits and traps in architectural order. When nothing is in flight, the trap is dispatched immediately as before. A uop that never completes still trips the existing liveness `simFailure`, so genuinely dropped instructions keep surfacing.

Touches only the probe — zero RTL change. Validated on the reproducer from #146 (`fnmsub.s` followed by `ecall`): with the fix, the FP writeback and commit are reported to RVLS before the trap and the program runs clean in lock-step.