### PR TITLE
Add Smcntrpmf/Shlcofideleg extension support

### DIFF
--- a/src/main/scala/vexiiriscv/Param.scala
+++ b/src/main/scala/vexiiriscv/Param.scala
@@ -578,6 +578,7 @@ class ParamSimple() {
   def withSstc = checkISA("sstc")
   def withSxaia = checkISA("smaia") || checkISA("ssaia")
   def withSscsrind = checkISA("sscsrind")
+  def withSmcntrpmf = checkISA("smcntrpmf")
 
   def withMul = checkISA("m") || checkISA("zmmul")
   def withDiv = checkISA("m")
@@ -1171,7 +1172,11 @@ class ParamSimple() {
     }
 
     plugins += new CsrRamPlugin()
-    if(withPerformanceCounters) plugins += new PerformanceCounterPlugin(additionalCounterCount = additionalPerformanceCounters, withScountovf = withSscofpmf)
+    if(withPerformanceCounters) plugins += new PerformanceCounterPlugin(
+      additionalCounterCount  = additionalPerformanceCounters,
+      withSmcntrpmf           = withSmcntrpmf,
+      withScountovf           = withSscofpmf
+    )
     plugins += new CsrAccessPlugin(early0, writeBackKey =  if(lanes == 1) "lane0" else "lane1")
     if(withIndirectCsr) plugins += new IndirectCsrPlugin(withSscsrind, privParam.withHypervisor && withSscsrind)
     plugins += new PrivilegedPlugin(privParam, withHartIdInput.mux(null, hartId until hartId+hartCount))

--- a/src/main/scala/vexiiriscv/Param.scala
+++ b/src/main/scala/vexiiriscv/Param.scala
@@ -575,6 +575,7 @@ class ParamSimple() {
   def withRvZbs = checkISA("zbs")
   def withRvb = checkISA("zba", "zbb", "zbc", "zbs")
   def withSscofpmf = checkISA("sscofpmf")
+  def withShlcofideleg = checkISA("shlcofideleg")
   def withSstc = checkISA("sstc")
   def withSxaia = checkISA("smaia") || checkISA("ssaia")
   def withSscsrind = checkISA("sscsrind")
@@ -1175,7 +1176,8 @@ class ParamSimple() {
     if(withPerformanceCounters) plugins += new PerformanceCounterPlugin(
       additionalCounterCount  = additionalPerformanceCounters,
       withSmcntrpmf           = withSmcntrpmf,
-      withScountovf           = withSscofpmf
+      withScountovf           = withSscofpmf,
+      withShlcofideleg        = withShlcofideleg
     )
     plugins += new CsrAccessPlugin(early0, writeBackKey =  if(lanes == 1) "lane0" else "lane1")
     if(withIndirectCsr) plugins += new IndirectCsrPlugin(withSscsrind, privParam.withHypervisor && withSscsrind)

--- a/src/main/scala/vexiiriscv/misc/PerformanceCounterPlugin.scala
+++ b/src/main/scala/vexiiriscv/misc/PerformanceCounterPlugin.scala
@@ -19,7 +19,8 @@ import scala.collection.mutable.ArrayBuffer
 class PerformanceCounterPlugin(var additionalCounterCount : Int,
                                var bufferWidth : Int = 8,
                                var withSmcntrpmf : Boolean = true,
-                               var withScountovf : Boolean = true) extends FiberPlugin with PerformanceCounterService{
+                               var withScountovf : Boolean = true,
+                               var withShlcofideleg : Boolean = false) extends FiberPlugin with PerformanceCounterService{
   def counterCount = 2 + additionalCounterCount
 
   case class Spec(id : Int, event : Bool)
@@ -165,8 +166,36 @@ class PerformanceCounterPlugin(var additionalCounterCount : Int,
         csr.read(CSR.SIE, 13 -> (ie & deleg))
         csr.writeWhen(ie, deleg, CSR.SIE, 13)
       }
+
+      val vs = (priv.implementHypervisor && withShlcofideleg) generate new Area {
+        val deleg = RegInit(False)
+        val active = sup.deleg && deleg
+
+        if(withShlcofideleg && withScountovf) {
+          deleg clearWhen(!sup.deleg)
+          csr.read(sup.deleg && deleg, CSR.HIDELEG, 13)
+          csr.writeWhen(deleg, sup.deleg, CSR.HIDELEG, 13)
+        }
+
+        csr.read(ip && active, CSR.VSIP, 13)
+        csr.writeWhen(ip, active, CSR.VSIP, 13)
+        csr.read(ie && active, CSR.VSIE, 13)
+        csr.writeWhen(ie, active, CSR.VSIE, 13)
+
+        priv.logic.harts(0).spec.addInterrupt(
+          ip && ie && active,
+          id = 13,
+          privilege = PrivilegeMode.VS,
+          delegators = List(
+            Delegator(True, PrivilegeMode.M),
+            Delegator(True, PrivilegeMode.S)
+          )
+        )
+      }
+      val nonGuestMode = (priv.implementHypervisor && withShlcofideleg).mux(!vs.active, True)
+
       priv.logic.harts(0).spec.addInterrupt(
-        ip && ie,
+        ip && ie && nonGuestMode,
         id = 13,
         privilege = priv.implementSupervisor.mux(PrivilegeMode.S, PrivilegeMode.M),
         delegators = priv.implementSupervisor.mux(List(Delegator(sup.deleg, PrivilegeMode.M)), Nil)

--- a/src/main/scala/vexiiriscv/misc/PerformanceCounterPlugin.scala
+++ b/src/main/scala/vexiiriscv/misc/PerformanceCounterPlugin.scala
@@ -49,7 +49,10 @@ class PerformanceCounterPlugin(var additionalCounterCount : Int,
     val eventInstructions = Vec.fill(widthOf(commitMask))(createEventPort(PerformanceCounterService.INSTRUCTIONS))
 
     var counterIdPtr = 0
-    class Counter extends Area{
+    val privValue = priv.getPrivilege(0)
+    val rawPrivValue = PrivilegeMode.mode(privValue)
+
+    class Counter(withOverflow: Boolean = true) extends Area{
       val alloc = ram.ramAllocate(if (withHigh) 2 else 1)
       val value = Reg(UInt(bufferWidth bits)).init(0)
       val needFlush = value.msb
@@ -60,13 +63,45 @@ class PerformanceCounterPlugin(var additionalCounterCount : Int,
       val scounteren = priv.p.withSupervisor generate csr.readWrite(RegInit(False), CSR.SCOUNTEREN, counterId)
       val hcounteren = priv.p.withHypervisor generate csr.readWrite(RegInit(False), CSR.HCOUNTEREN, counterId)
       val mcountinhibit = csr.readWrite(RegInit(False), CSR.MCOUNTINHIBIT, counterId)
+
+      val MINH    = RegInit(False)
+      val SINH    = RegInit(False)
+      val UINH    = RegInit(False)
+      val VSINH   = RegInit(False)
+      val VUINH   = RegInit(False)
+      val OF      = withOverflow generate RegInit(False)
+      val inhibit = CombInit(mcountinhibit)
+      val ofRead  = withOverflow generate CombInit(OF)
+
+      def mappingCfgCsr(eb: Int, eo: Int) = new Area {
+        if (withOverflow) ofRead clearWhen(!mcounteren && rawPrivValue =/= PrivilegeMode.M)
+
+        if (withOverflow) csr.readWrite(eb, 63-eo -> OF)
+        csr.readWrite(eb, 62-eo -> MINH)
+        inhibit.setWhen(privValue === PrivilegeMode.M && MINH)
+        if (priv.p.withSupervisor) {
+          csr.readWrite(eb, 61 - eo -> SINH)
+          inhibit.setWhen(privValue === PrivilegeMode.S && SINH)
+        }
+        if (priv.p.withUser) {
+          csr.readWrite(eb, 60 - eo -> UINH)
+          inhibit.setWhen(privValue === PrivilegeMode.U && UINH)
+        }
+        if (priv.p.withHypervisor) {
+          csr.readWrite(eb, 59 - eo -> VSINH, 58 - eo -> VUINH)
+          inhibit.setWhen(privValue === PrivilegeMode.VS && VSINH)
+          inhibit.setWhen(privValue === PrivilegeMode.VU && VUINH)
+          if (withOverflow) ofRead clearWhen(!hcounteren && PrivilegeMode.isGuest(privValue))
+        }
+      }
+
     }
     case class Mapping(csrId : Int, alloc : CsrRamAllocation, offset : Int)
     val mappings = ArrayBuffer[Mapping]()
     val counters = new Area{
-      val cycle = new Counter()
+      val cycle = new Counter(withOverflow = false)
       counterIdPtr += 1 //skip time
-      val instret = new Counter()
+      val instret = new Counter(withOverflow = false)
       val additionals = List.fill(additionalCounterCount)(new Counter)
 
       eventCycles := True
@@ -74,6 +109,18 @@ class PerformanceCounterPlugin(var additionalCounterCount : Int,
 
       cycle.value := cycle.value + (!cycle.mcountinhibit).asUInt
       instret.value := instret.value + RegNext(commitCount.andMask(!instret.mcountinhibit)).init(0)
+
+      Riscv.XLEN.get match {
+        case 32 => {
+          cycle.mappingCfgCsr(CSR.MCYCLECFGH, 32)
+          instret.mappingCfgCsr(CSR.MINSTRETCFGH, 32)
+          csr.allowCsr(CsrListFilter(List(CSR.MCYCLECFG, CSR.MINSTRETCFG)))
+        }
+        case 64 => {
+          cycle.mappingCfgCsr(CSR.MCYCLECFG, 0)
+          instret.mappingCfgCsr(CSR.MINSTRETCFG, 0)
+        }
+      }
 
       mappings += Mapping(CSR.MCYCLE, cycle.alloc, 0)
       mappings += Mapping(CSR.UCYCLE, cycle.alloc, 0)
@@ -136,18 +183,12 @@ class PerformanceCounterPlugin(var additionalCounterCount : Int,
       val counter = counters.additionals(id-3)
       val eventId = Reg(UInt(events.selWidth bits)) init(0)
       val overflowEvent = False
-      val OF   = RegInit(False) setWhen(overflowEvent)
-      val MINH = RegInit(False)
-      val SINH = RegInit(False)
-      val UINH = RegInit(False)
-      val VSINH = RegInit(False)
-      val VUINH = RegInit(False)
+      counter.OF setWhen(overflowEvent)
 
-      interrupt.ip.setWhen(overflowEvent && !OF)
+      interrupt.ip.setWhen(overflowEvent && !counter.OF)
 
       val incr    = if(events.sums.isEmpty) U(0) else events.sums.map(e => e._2.andMask(eventId === e._1).resize(events.widthMax)).toList.reduceBalancedTree(_ | _)
-      val inhibit = CombInit(counter.mcountinhibit)
-      when(!inhibit) {
+      when(!counter.inhibit) {
         counter.value := counter.value + incr
       }
       csr.readWrite(CSR.MHPMEVENT0 + id, 0 -> eventId)
@@ -156,28 +197,9 @@ class PerformanceCounterPlugin(var additionalCounterCount : Int,
         case 32 => (CSR.MHPMEVENT0H + id, 32)
         case 64 => (CSR.MHPMEVENT0  + id, 0)
       }
-      val privValue = priv.getPrivilege(0)
-      val rawPrivValue = PrivilegeMode.mode(privValue)
-      val ofRead = CombInit(OF)
-      if(withScountovf && priv.implementSupervisor) csr.read(CSR.SCOUNTOVF, id -> ofRead)
-      ofRead clearWhen(!counter.mcounteren && rawPrivValue =/= PrivilegeMode.M)
+      counter.mappingCfgCsr(eb, eo)
 
-      csr.readWrite(eb, 63-eo -> OF, 62-eo -> MINH)
-      inhibit.setWhen(privValue === PrivilegeMode.M && MINH)
-      if (priv.p.withSupervisor) {
-        csr.readWrite(eb, 61 - eo -> SINH)
-        inhibit.setWhen(privValue === PrivilegeMode.S && SINH)
-      }
-      if (priv.p.withUser) {
-        csr.readWrite(eb, 60 - eo -> UINH)
-        inhibit.setWhen(privValue === PrivilegeMode.U && UINH)
-      }
-      if (priv.p.withHypervisor) {
-        csr.readWrite(eb, 59 - eo -> VSINH, 58 - eo -> VUINH)
-        inhibit.setWhen(privValue === PrivilegeMode.VS && VSINH)
-        inhibit.setWhen(privValue === PrivilegeMode.VU && VUINH)
-        ofRead clearWhen(!counter.hcounteren && PrivilegeMode.isGuest(privValue))
-      }
+      if(withScountovf && priv.implementSupervisor) csr.read(CSR.SCOUNTOVF, id -> counter.ofRead)
     }
 
 

--- a/src/main/scala/vexiiriscv/misc/PerformanceCounterPlugin.scala
+++ b/src/main/scala/vexiiriscv/misc/PerformanceCounterPlugin.scala
@@ -18,6 +18,7 @@ import scala.collection.mutable.ArrayBuffer
  */
 class PerformanceCounterPlugin(var additionalCounterCount : Int,
                                var bufferWidth : Int = 8,
+                               var withSmcntrpmf : Boolean = true,
                                var withScountovf : Boolean = true) extends FiberPlugin with PerformanceCounterService{
   def counterCount = 2 + additionalCounterCount
 
@@ -110,7 +111,7 @@ class PerformanceCounterPlugin(var additionalCounterCount : Int,
       cycle.value := cycle.value + (!cycle.mcountinhibit).asUInt
       instret.value := instret.value + RegNext(commitCount.andMask(!instret.mcountinhibit)).init(0)
 
-      Riscv.XLEN.get match {
+      if (withSmcntrpmf) Riscv.XLEN.get match {
         case 32 => {
           cycle.mappingCfgCsr(CSR.MCYCLECFGH, 32)
           instret.mappingCfgCsr(CSR.MINSTRETCFGH, 32)

--- a/src/main/scala/vexiiriscv/riscv/Const.scala
+++ b/src/main/scala/vexiiriscv/riscv/Const.scala
@@ -193,10 +193,14 @@ object CSR {
   def MHPMCOUNTER0H = 0xB80 // MRW Machine instructions-retired counter.
   def MHPMCOUNTER3H = 0xB83 // MRW Machine instructions-retired counter.
   def MHPMEVENT0 = 0x320 // MRW Machine instructions-retired counter.
+  def MCYCLECFG = 0x321 // MRW Machine cycle counter configuration register.
+  def MINSTRETCFG = 0x322 // MRW Machine instret counter configuration register.
   def MHPMEVENT3 = 0x323 // MRW Machine instructions-retired counter.
   val MCOUNTEREN  = 0x306
   val MCOUNTINHIBIT = 0x320
   def MHPMEVENT0H = 0x720 // MRW Machine instructions-retired counter.
+  def MCYCLECFGH = 0x721 // MRW Upper 32 bits of mcyclecfg, RV32 only.
+  def MINSTRETCFGH = 0x722 // MRW Upper 32 bits of minstretcfg, RV32 only.
   def MTOPI     = 0xFB0 // MRO Machine top interrupt.
 
   val PMPCFG = 0x3a0


### PR DESCRIPTION
Currently the code of performance counter plugin is restructured by the previous #120, now we can add Smcntrpmf support with only code moving. Also add Shlcofideleg extension as improve the hypervisor support.