### PR TITLE
Add ASID support for the MMU

### DIFF
--- a/src/main/scala/vexiiriscv/Param.scala
+++ b/src/main/scala/vexiiriscv/Param.scala
@@ -854,7 +854,8 @@ class ParamSimple() {
       case true => plugins += new vexiiriscv.memory.MmuPlugin(
         spec = if (xlen == 32) MmuSpec.sv32 else MmuSpec.sv39,
         physicalWidth = physicalWidth,
-        asidWidth = asidWidth
+        asidWidth = asidWidth,
+        withGuestSfenceCheck = withHypervisor
       )
     }
     (withRvh && withMmu) match {

--- a/src/main/scala/vexiiriscv/execute/EnvPlugin.scala
+++ b/src/main/scala/vexiiriscv/execute/EnvPlugin.scala
@@ -5,7 +5,7 @@ import spinal.lib._
 import spinal.lib.misc.plugin.FiberPlugin
 import spinal.lib.misc.pipeline._
 import vexiiriscv.misc.{PrivilegedPlugin, TrapReason, TrapService}
-import vexiiriscv.riscv.{CSR, PrivilegeMode, Rvi, Rvh}
+import vexiiriscv.riscv.{Const, CSR, PrivilegeMode, Rvi, Rvh}
 import vexiiriscv._
 import vexiiriscv.Global._
 import vexiiriscv.decode.Decode
@@ -170,6 +170,8 @@ class EnvPlugin(layer : LaneLayer,
               trapPort.tval := srcp.SRC1.asBits.resized
               trapPort.tval2 := srcp.SRC2.asBits.resized
               trapPort.arg(0) := isGuest
+              trapPort.arg(1) := Decode.UOP(Const.rs1Range) === 0
+              trapPort.arg(2) := Decode.UOP(Const.rs2Range) === 0
             }
             if(ps.p.withHypervisor) {
               when(privilege === PrivilegeMode.VU || privilege === PrivilegeMode.VS && vmaKoMapping(PrivilegeMode.VS)) {
@@ -199,6 +201,8 @@ class EnvPlugin(layer : LaneLayer,
               trapPort.tval := srcp.SRC1.asBits.resized
               trapPort.tval2 := srcp.SRC2.asBits.resized
               trapPort.arg(0) := True
+              trapPort.arg(1) := Decode.UOP(Const.rs1Range) === 0
+              trapPort.arg(2) := Decode.UOP(Const.rs2Range) === 0
             }
             when(PrivilegeMode.isGuest(privilege)) {
               trapPort.code := CSR.MCAUSE_ENUM.VIRTUAL_INSTRUCTION

--- a/src/main/scala/vexiiriscv/execute/EnvPlugin.scala
+++ b/src/main/scala/vexiiriscv/execute/EnvPlugin.scala
@@ -32,6 +32,7 @@ class EnvPlugin(layer : LaneLayer,
     val ps = host[PrivilegedPlugin]
     val ioRetainer = retains(sp.elaborationLock, ts.trapLock)
     awaitBuild()
+    import SrcKeys._
 
     val age = el.getExecuteAge(executeAt)
     val trapPort = ts.newTrap(age, Execute.LANE_AGE_WIDTH)
@@ -45,9 +46,9 @@ class EnvPlugin(layer : LaneLayer,
 
     add(Rvi.FENCE_I).decode(OP -> EnvPluginOp.FENCE_I)
     add(Rvi.WFI).decode(OP -> EnvPluginOp.WFI)
-    if (ps.implementSupervisor) add(Rvi.SFENCE_VMA).decode(OP -> EnvPluginOp.SFENCE_VMA)
+    if (ps.implementSupervisor) add(Rvi.SFENCE_VMA).srcs(SRC1.RF, SRC2.RF).decode(OP -> EnvPluginOp.SFENCE_VMA)
     if (ps.implementHypervisor) {
-      add(Rvh.HFENCE_VVMA).decode(OP -> EnvPluginOp.HFENCE_VVMA)
+      add(Rvh.HFENCE_VVMA).srcs(SRC1.RF, SRC2.RF).decode(OP -> EnvPluginOp.HFENCE_VVMA)
       add(Rvh.HFENCE_GVMA).decode(OP -> EnvPluginOp.HFENCE_GVMA)
     }
 
@@ -166,6 +167,8 @@ class EnvPlugin(layer : LaneLayer,
               commit := True
               trapPort.exception := False
               trapPort.code := TrapReason.SFENCE_VMA
+              trapPort.tval := srcp.SRC1.asBits.resized
+              trapPort.tval2 := srcp.SRC2.asBits.resized
             }
             if(ps.p.withHypervisor) {
               when(privilege === PrivilegeMode.VU || privilege === PrivilegeMode.VS && vmaKoMapping(PrivilegeMode.VS)) {
@@ -192,6 +195,8 @@ class EnvPlugin(layer : LaneLayer,
               commit := True
               trapPort.exception := False
               trapPort.code := TrapReason.SFENCE_VMA
+              trapPort.tval := srcp.SRC1.asBits.resized
+              trapPort.tval2 := srcp.SRC2.asBits.resized
             }
             when(PrivilegeMode.isGuest(privilege)) {
               trapPort.code := CSR.MCAUSE_ENUM.VIRTUAL_INSTRUCTION

--- a/src/main/scala/vexiiriscv/execute/EnvPlugin.scala
+++ b/src/main/scala/vexiiriscv/execute/EnvPlugin.scala
@@ -169,6 +169,7 @@ class EnvPlugin(layer : LaneLayer,
               trapPort.code := TrapReason.SFENCE_VMA
               trapPort.tval := srcp.SRC1.asBits.resized
               trapPort.tval2 := srcp.SRC2.asBits.resized
+              trapPort.arg(0) := isGuest
             }
             if(ps.p.withHypervisor) {
               when(privilege === PrivilegeMode.VU || privilege === PrivilegeMode.VS && vmaKoMapping(PrivilegeMode.VS)) {
@@ -197,6 +198,7 @@ class EnvPlugin(layer : LaneLayer,
               trapPort.code := TrapReason.SFENCE_VMA
               trapPort.tval := srcp.SRC1.asBits.resized
               trapPort.tval2 := srcp.SRC2.asBits.resized
+              trapPort.arg(0) := True
             }
             when(PrivilegeMode.isGuest(privilege)) {
               trapPort.code := CSR.MCAUSE_ENUM.VIRTUAL_INSTRUCTION

--- a/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
@@ -288,11 +288,7 @@ class MmuPlugin(var spec : MmuSpec,
     csr.writeCancel(CSR.SATP, satpModeWrite =/= 0 && satpModeWrite =/= spec.satpMode)
 
     csr.allowCsr(CSR.SATP, !priv.logic.harts(0).m.status.tvm || priv.isMachine(0))
-    csr.onDecode(CSR.SATP) {
-      when (csr.bus.decode.write) {
-        csr.bus.decode.doTrap(TrapReason.SFENCE_VMA)
-      }
-    }
+    csr.trapNextOnWrite += CsrListFilter(List(CSR.SATP))
 
     if (priv.implementHypervisor) {
       csr.readWrite(CSR.VSSTATUS, 19 -> vsstatus.mxr, 18 -> vsstatus.sum)
@@ -304,11 +300,7 @@ class MmuPlugin(var spec : MmuSpec,
       csr.remapWhen(CSR.SATP, CSR.VSATP, PrivilegeMode.isGuest(priv.getPrivilege(0)))
 
       csr.allowCsr(CSR.VSATP, !priv.logic.harts(0).h.status.vtvm || priv.getPrivilege(0) =/= PrivilegeMode.VS)
-      csr.onDecode(CSR.VSATP) {
-        when (csr.bus.decode.write) {
-          csr.bus.decode.doTrap(TrapReason.SFENCE_VMA)
-        }
-      }
+      csr.trapNextOnWrite += CsrListFilter(List(CSR.VSATP))
     }
 
     csrLock.release()

--- a/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
@@ -677,33 +677,24 @@ class MmuPlugin(var spec : MmuSpec,
         }
       } otherwise {
         assert(HART_COUNT.get == 1)
+        /* For addressed invalidation, each way only has at most one set will hit */
+        for (storage <- storages; sl <- storage.sl) {
+          val invalidateReadAddress = Mux(anyAddress, counter.resized, address(sl.lineRange))
+          val mask = B(sl.ways.map(way => {
+            val entry = way.readAsync(invalidateReadAddress)
+            asidHit(entry) && addressHit(entry) && guestHit(entry)
+          }))
+          sl.write.mask := mask
+          sl.write.address := invalidateReadAddress
+          sl.write.data.valid := False
+        }
         when (anyAddress) {
-          for (storage <- storages; sl <- storage.sl) {
-            val mask = B(sl.ways.map(way => {
-              val entry = way.readAsync(counter.resized)
-              asidHit(entry) && guestHit(entry)
-            }))
-            sl.write.mask := mask
-            sl.write.address := counter.resized
-            sl.write.data.valid := False
-          }
           counter := counter + 1
           when(counter.andR){
             busy := False
             arbiter.io.output.ready := True
           }
         } otherwise {
-          /* Optimize for each way only has at most one set will hit */
-          for (storage <- storages; sl <- storage.sl) {
-            val targetAddress = address(sl.lineRange)
-            val mask = B(sl.ways.map(way => {
-              val entry = way.readAsync(targetAddress)
-              asidHit(entry) && addressHit(entry) && guestHit(entry)
-            }))
-            sl.write.mask := mask
-            sl.write.address := targetAddress
-            sl.write.data.valid := False
-          }
           busy := False
           arbiter.io.output.ready := True
         }

--- a/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
@@ -207,7 +207,8 @@ trait GenericMmuPlugin extends AddressTranslationService {
  */
 class MmuPlugin(var spec : MmuSpec,
                 var physicalWidth : Int,
-                var asidWidth : Int) extends FiberPlugin with GenericMmuPlugin{
+                var asidWidth : Int,
+                var withGuestSfenceCheck : Boolean) extends FiberPlugin with GenericMmuPlugin{
   override def isShadowMmu : Boolean = false
 
   val api = during build new Area{
@@ -217,7 +218,8 @@ class MmuPlugin(var spec : MmuSpec,
 
   override def getInvalidationPortParam = AddressTranslationInvalidationParam(
     asidWidth       = asidWidth,
-    requestAddress  = true
+    requestAddress  = true,
+    requestGuest    = withGuestSfenceCheck
   )
 
   override def getSignExtension(kind: AddressTranslationPortUsage, rawAddress: UInt): Bool = {
@@ -241,6 +243,8 @@ class MmuPlugin(var spec : MmuSpec,
 
 
     awaitBuild()
+
+    assert(!withGuestSfenceCheck || priv.implementHypervisor)
 
     PHYSICAL_WIDTH.set(physicalWidth)
     VIRTUAL_WIDTH.set(spec.virtualWidth)
@@ -649,12 +653,15 @@ class MmuPlugin(var spec : MmuSpec,
       val busy = RegInit(False)
       val asid = RegInit(B(0, asidWidth bits))
       val address = RegInit(U(0, MIXED_WIDTH bits))
+      val guest = withGuestSfenceCheck generate RegInit(False)
+      val both = withGuestSfenceCheck generate RegInit(False)
 
       val anyAsid = (asidWidth > 0).mux(asid === 0, True)
       val anyAddress = address === 0
 
       def asidHit(entry: MmuTlbStorageEntry) = (asidWidth > 0).mux(anyAsid || entry.asid === asid, True)
       def addressHit(entry: MmuTlbStorageEntry) = anyAddress || entry.hit(address)
+      def guestHit(entry: MmuTlbStorageEntry) = withGuestSfenceCheck.mux(both || entry.guest === guest, True)
 
       arbiter.io.output.ready := False
       when(!busy){
@@ -663,12 +670,19 @@ class MmuPlugin(var spec : MmuSpec,
           busy := True
           asid := arbiter.io.output.asid.resized
           address := arbiter.io.output.address.resized
+          if (withGuestSfenceCheck) {
+            guest := arbiter.io.output.guest
+            both := arbiter.io.output.both
+          }
         }
       } otherwise {
         assert(HART_COUNT.get == 1)
         when (anyAddress) {
           for (storage <- storages; sl <- storage.sl) {
-            val mask = B(sl.ways.map(way => asidHit(way.readAsync(counter.resized))))
+            val mask = B(sl.ways.map(way => {
+              val entry = way.readAsync(counter.resized)
+              asidHit(entry) && guestHit(entry)
+            }))
             sl.write.mask := mask
             sl.write.address := counter.resized
             sl.write.data.valid := False
@@ -684,7 +698,7 @@ class MmuPlugin(var spec : MmuSpec,
             val targetAddress = address(sl.lineRange)
             val mask = B(sl.ways.map(way => {
               val entry = way.readAsync(targetAddress)
-              asidHit(entry) && addressHit(entry)
+              asidHit(entry) && addressHit(entry) && guestHit(entry)
             }))
             sl.write.mask := mask
             sl.write.address := targetAddress

--- a/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
@@ -83,6 +83,7 @@ object MmuSpec{
 case class MmuTlbStorageEntryParam(
   asidWidth: Int,
   checkUser: Boolean,
+  checkGlobal: Boolean,
   checkGuest: Boolean
 )
 
@@ -109,19 +110,21 @@ class MmuTlbStorageEntry(
   val allowRead, allowWrite, allowExecute = Bool()
   val allowUser = p.checkUser generate Bool()
   val guest = p.checkGuest generate Bool()
+  val global = p.checkGlobal generate Bool()
 
   def hit(address : UInt) = /*valid && */virtualAddress === address(spec.levels(levelId).virtualOffset + log2Up(depth), vw - log2Up(depth) bits)
   def hit(query : MmuTlbStorageEntryQuery): Bool = {
     val addressCheck = hit(query.address)
-    val asidCheck = (p.asidWidth > 0).mux(asid === query.asid, True)
+    val asidCheck = (p.asidWidth > 0).mux(asid === query.asid, True) || p.checkGlobal.mux(global, False)
     val guestCheck = p.checkGuest.mux(guest === query.guest, True)
     addressCheck && asidCheck && guestCheck
   }
   def needFlush(query : MmuTlbStorageEntryQuery, anyAsid : Bool, anyAddress : Bool) = {
     val addressCheck = hit(query.address) || anyAddress
-    val asidCheck = (p.asidWidth > 0).mux(asid === query.asid, True) || anyAsid
+    val asidCheck = (p.asidWidth > 0).mux(asid === query.asid, True)
+    val globalCheck = (asidCheck && p.checkGlobal.mux(!global, True)) || anyAsid
     val guestCheck = p.checkGuest.mux(guest === query.guest, True)
-    addressCheck && asidCheck && guestCheck
+    addressCheck && globalCheck && guestCheck
   }
   def physicalAddressFrom(address : UInt) = physicalAddress @@ address(0, spec.levels(levelId).physicalOffset bits)
 }
@@ -227,6 +230,8 @@ class MmuPlugin(var spec : MmuSpec,
                 var physicalWidth : Int,
                 var asidWidth : Int,
                 var withGuestSfenceCheck : Boolean) extends FiberPlugin with GenericMmuPlugin{
+  def withGlobalCheck = asidWidth > 0
+
   override def isShadowMmu : Boolean = false
 
   val api = during build new Area{
@@ -333,6 +338,7 @@ class MmuPlugin(var spec : MmuSpec,
     val tlbGenerateParam = MmuTlbStorageEntryParam(
       asidWidth   = asidWidth,
       checkUser   = true,
+      checkGlobal = withGlobalCheck,
       checkGuest  = priv.implementHypervisor
     )
     val storages = for(ss <- storageSpecs) yield new MmuTlbStorage(spec, physicalWidth, tlbGenerateParam, ss)
@@ -462,6 +468,7 @@ class MmuPlugin(var spec : MmuSpec,
       val storageOhReg = Reg(Bits(storages.size bits))
       val storageEnable = Reg(Bool())
       val isTwoStage = Reg(Bool())
+      val isGlobal = Reg(Bool())
 
       arbiter.io.output.ready := False
       IDLE whenIsActive {
@@ -476,6 +483,7 @@ class MmuPlugin(var spec : MmuSpec,
           virtual := arbiter.io.output.address
           load.address := (ppn @@ spec.levels.last.vpn(arbiter.io.output.address) @@ U(0, log2Up(spec.entryBytes) bits)).resized
           isTwoStage := arbiter.io.output.indirect
+          isGlobal := False
           arbiter.io.output.ready := True
           goto(CMD(spec.levels.size - 1))
         }
@@ -616,6 +624,7 @@ class MmuPlugin(var spec : MmuSpec,
         RSP(levelId) whenIsActive{
           if(levelId == 0) load.exception setWhen(!load.leaf)
           when(load.rsp.valid){
+            isGlobal := load.flags.G | isGlobal
             levelId match {
               case 0 => rspCheck
               case _ => {
@@ -654,6 +663,7 @@ class MmuPlugin(var spec : MmuSpec,
             storageLevel.write.data.allowWrite      := load.flags.W && load.flags.D
             storageLevel.write.data.allowExecute    := load.flags.X
             storageLevel.write.data.allowUser       := load.flags.U
+            if (asidWidth > 0) storageLevel.write.data.global := isGlobal
             if (priv.implementHypervisor) storageLevel.write.data.guest := isTwoStage
 
             storageLevel.allocId.increment()

--- a/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
@@ -655,23 +655,49 @@ class MmuPlugin(var spec : MmuSpec,
       val depthMax = storageSpecs.map(_.p.levels.map(_.sets).max).max
       val counter = Reg(UInt(log2Up(depthMax) bits))
       val busy = RegInit(False)
+      val asid = RegInit(B(0, asidWidth bits))
+      val address = RegInit(U(0, MIXED_WIDTH bits))
+
+      val anyAsid = (asidWidth > 0).mux(asid === 0, True)
+      val anyAddress = address === 0
+
+      def asidHit(entry: MmuTlbStorageEntry) = (asidWidth > 0).mux(anyAsid || entry.asid === asid, True)
+      def addressHit(entry: MmuTlbStorageEntry) = anyAddress || entry.hit(address)
 
       arbiter.io.output.ready := False
       when(!busy){
         counter := 0
         when (arbiter.io.output.valid) {
           busy := True
+          asid := arbiter.io.output.asid.resized
+          address := arbiter.io.output.address.resized
         }
       } otherwise {
         assert(HART_COUNT.get == 1)
-        for (storage <- storages;
-             sl <- storage.sl) {
-          sl.write.mask := (default -> true)
-          sl.write.address := counter.resized
-          sl.write.data.valid := False
-        }
-        counter := counter + 1
-        when(counter.andR){
+        when (anyAddress) {
+          for (storage <- storages; sl <- storage.sl) {
+            val mask = B(sl.ways.map(way => asidHit(way.readAsync(counter.resized))))
+            sl.write.mask := mask
+            sl.write.address := counter.resized
+            sl.write.data.valid := False
+          }
+          counter := counter + 1
+          when(counter.andR){
+            busy := False
+            arbiter.io.output.ready := True
+          }
+        } otherwise {
+          /* Optimize for each way only has at most one set will hit */
+          for (storage <- storages; sl <- storage.sl) {
+            val targetAddress = address(sl.lineRange)
+            val mask = B(sl.ways.map(way => {
+              val entry = way.readAsync(targetAddress)
+              asidHit(entry) && addressHit(entry)
+            }))
+            sl.write.mask := mask
+            sl.write.address := targetAddress
+            sl.write.data.valid := False
+          }
           busy := False
           arbiter.io.output.ready := True
         }

--- a/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
@@ -81,6 +81,7 @@ object MmuSpec{
 }
 
 case class MmuTlbStorageEntryParam(
+  asidWidth: Int,
   checkUser: Boolean,
   checkGuest: Boolean
 )
@@ -98,6 +99,7 @@ class MmuTlbStorageEntry(
   val valid = Bool()
   val virtualAddress  = UInt(vw-log2Up(depth) bits)
   val physicalAddress = UInt(pw bits)
+  val asid = Bits(p.asidWidth bits)
   val allowRead, allowWrite, allowExecute = Bool()
   val allowUser = p.checkUser generate Bool()
   val guest = p.checkGuest generate Bool()
@@ -310,6 +312,7 @@ class MmuPlugin(var spec : MmuSpec,
     assert(storageSpecs.map(_.p.priority).distinct.size == storageSpecs.size, "MMU storages needs different priorities")
     // Implement the hardware for all the TLB storages
     val tlbGenerateParam = MmuTlbStorageEntryParam(
+      asidWidth   = asidWidth,
       checkUser   = true,
       checkGuest  = priv.implementHypervisor
     )

--- a/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
@@ -469,6 +469,7 @@ class MmuPlugin(var spec : MmuSpec,
       val storageEnable = Reg(Bool())
       val isTwoStage = Reg(Bool())
       val isGlobal = Reg(Bool())
+      val asid = Reg(Bits(asidWidth bits))
 
       arbiter.io.output.ready := False
       IDLE whenIsActive {
@@ -484,6 +485,10 @@ class MmuPlugin(var spec : MmuSpec,
           load.address := (ppn @@ spec.levels.last.vpn(arbiter.io.output.address) @@ U(0, log2Up(spec.entryBytes) bits)).resized
           isTwoStage := arbiter.io.output.indirect
           isGlobal := False
+          asid := priv.implementHypervisor.mux(
+            Mux(arbiter.io.output.indirect, vsatp.asid, satp.asid),
+            satp.asid
+          )
           arbiter.io.output.ready := True
           goto(CMD(spec.levels.size - 1))
         }
@@ -650,7 +655,6 @@ class MmuPlugin(var spec : MmuSpec,
             val storageLevelId = storage.self.p.levels.filter(_.id <= levelId).map(_.id).max
             val storageLevel = storage.sl.find(_.slp.id == storageLevelId).get
             val specLevel = storageLevel.level
-            val currentAsid = priv.implementHypervisor.mux(Mux(isTwoStage, vsatp.asid, satp.asid), satp.asid)
 
             val sel = storageOhReg(sid)
             storageLevel.write.mask                 := UIntToOh(storageLevel.allocId).andMask(sel).resized
@@ -658,7 +662,7 @@ class MmuPlugin(var spec : MmuSpec,
             storageLevel.write.data.valid           := True
             storageLevel.write.data.virtualAddress  := virtual(specLevel.virtualOffset + log2Up(storageLevel.slp.sets), widthOf(storageLevel.write.data.virtualAddress) bits)
             storageLevel.write.data.physicalAddress := (load.levelToPhysicalAddress(levelId) >> specLevel.virtualOffset).resized
-            if (asidWidth > 0) storageLevel.write.data.asid := currentAsid
+            if (asidWidth > 0) storageLevel.write.data.asid := asid
             storageLevel.write.data.allowRead       := load.flags.R
             storageLevel.write.data.allowWrite      := load.flags.W && load.flags.D
             storageLevel.write.data.allowExecute    := load.flags.X

--- a/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
@@ -215,6 +215,11 @@ class MmuPlugin(var spec : MmuSpec,
     val lsuTranslationEnable = Bool()
   }
 
+  override def getInvalidationPortParam = AddressTranslationInvalidationParam(
+    asidWidth       = asidWidth,
+    requestAddress  = true
+  )
+
   override def getSignExtension(kind: AddressTranslationPortUsage, rawAddress: UInt): Bool = {
     val translationEnable = kind match {
       case AddressTranslationPortUsage.FETCH => api.fetchTranslationEnable

--- a/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
@@ -86,6 +86,12 @@ case class MmuTlbStorageEntryParam(
   checkGuest: Boolean
 )
 
+case class MmuTlbStorageEntryQuery(
+  address: UInt,
+  asid: Bits,
+  guest: Bool
+)
+
 class MmuTlbStorageEntry(
   spec : MmuSpec,
   physicalWidth : Int,
@@ -105,6 +111,18 @@ class MmuTlbStorageEntry(
   val guest = p.checkGuest generate Bool()
 
   def hit(address : UInt) = /*valid && */virtualAddress === address(spec.levels(levelId).virtualOffset + log2Up(depth), vw - log2Up(depth) bits)
+  def hit(query : MmuTlbStorageEntryQuery): Bool = {
+    val addressCheck = hit(query.address)
+    val asidCheck = (p.asidWidth > 0).mux(asid === query.asid, True)
+    val guestCheck = p.checkGuest.mux(guest === query.guest, True)
+    addressCheck && asidCheck && guestCheck
+  }
+  def needFlush(query : MmuTlbStorageEntryQuery, anyAsid : Bool, anyAddress : Bool) = {
+    val addressCheck = hit(query.address) || anyAddress
+    val asidCheck = (p.asidWidth > 0).mux(asid === query.asid, True) || anyAsid
+    val guestCheck = p.checkGuest.mux(guest === query.guest, True)
+    addressCheck && asidCheck && guestCheck
+  }
   def physicalAddressFrom(address : UInt) = physicalAddress @@ address(0, spec.levels(levelId).physicalOffset bits)
 }
 
@@ -346,15 +364,19 @@ class MmuPlugin(var spec : MmuSpec,
       val storage = storages.find(_.self == ps.ss).get
       val read = for (sl <- storage.sl) yield new Area {
         val readAddress = readStage(ps.req.PRE_ADDRESS)(sl.lineRange)
-        val forceGuest = ctrlStage(ps.req.FORCE_GUEST) || effectiveGuest
+        val forceGuest = hitsStage(ps.req.FORCE_GUEST) || effectiveGuest
         val currentAsid = priv.implementHypervisor.mux(Mux(forceGuest, vsatp.asid, satp.asid), satp.asid)
         for ((way, wayId) <- sl.ways.zipWithIndex) {
+          val query = MmuTlbStorageEntryQuery(
+            address = hitsStage(ps.req.PRE_ADDRESS),
+            asid    = currentAsid,
+            guest   = priv.implementHypervisor.mux(forceGuest, True)
+          )
+
           readStage(sl.keys.ENTRIES)(wayId) := way.readAsync(readAddress)
-          hitsStage(sl.keys.HITS_PRE_VALID)(wayId) := hitsStage(sl.keys.ENTRIES)(wayId).hit(hitsStage(ps.req.PRE_ADDRESS))
+          hitsStage(sl.keys.HITS_PRE_VALID)(wayId) := hitsStage(sl.keys.ENTRIES)(wayId).hit(query)
           ctrlStage(sl.keys.HITS)(wayId) := ctrlStage(sl.keys.HITS_PRE_VALID)(wayId) &&
-            ctrlStage(sl.keys.ENTRIES)(wayId).valid &&
-            (asidWidth > 0).mux(ctrlStage(sl.keys.ENTRIES)(wayId).asid === currentAsid, True) &&
-            priv.implementHypervisor.mux(ctrlStage(sl.keys.ENTRIES)(wayId).guest === forceGuest, True)
+            ctrlStage(sl.keys.ENTRIES)(wayId).valid
         }
       }
 
@@ -658,10 +680,11 @@ class MmuPlugin(var spec : MmuSpec,
 
       val anyAsid = (asidWidth > 0).mux(asid === 0, True)
       val anyAddress = address === 0
-
-      def asidHit(entry: MmuTlbStorageEntry) = (asidWidth > 0).mux(anyAsid || entry.asid === asid, True)
-      def addressHit(entry: MmuTlbStorageEntry) = anyAddress || entry.hit(address)
-      def guestHit(entry: MmuTlbStorageEntry) = withGuestSfenceCheck.mux(both || entry.guest === guest, True)
+      val query = MmuTlbStorageEntryQuery(
+        address = address,
+        asid    = asid,
+        guest   = withGuestSfenceCheck.mux(guest, False)
+      )
 
       arbiter.io.output.ready := False
       when(!busy){
@@ -682,7 +705,7 @@ class MmuPlugin(var spec : MmuSpec,
           val invalidateReadAddress = Mux(anyAddress, counter.resized, address(sl.lineRange))
           val mask = B(sl.ways.map(way => {
             val entry = way.readAsync(invalidateReadAddress)
-            asidHit(entry) && addressHit(entry) && guestHit(entry)
+            entry.needFlush(query, anyAsid, anyAddress) || both
           }))
           sl.write.mask := mask
           sl.write.address := invalidateReadAddress

--- a/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
@@ -351,11 +351,13 @@ class MmuPlugin(var spec : MmuSpec,
       val read = for (sl <- storage.sl) yield new Area {
         val readAddress = readStage(ps.req.PRE_ADDRESS)(sl.lineRange)
         val forceGuest = ctrlStage(ps.req.FORCE_GUEST) || effectiveGuest
+        val currentAsid = priv.implementHypervisor.mux(Mux(forceGuest, vsatp.asid, satp.asid), satp.asid)
         for ((way, wayId) <- sl.ways.zipWithIndex) {
           readStage(sl.keys.ENTRIES)(wayId) := way.readAsync(readAddress)
           hitsStage(sl.keys.HITS_PRE_VALID)(wayId) := hitsStage(sl.keys.ENTRIES)(wayId).hit(hitsStage(ps.req.PRE_ADDRESS))
           ctrlStage(sl.keys.HITS)(wayId) := ctrlStage(sl.keys.HITS_PRE_VALID)(wayId) &&
             ctrlStage(sl.keys.ENTRIES)(wayId).valid &&
+            (asidWidth > 0).mux(ctrlStage(sl.keys.ENTRIES)(wayId).asid === currentAsid, True) &&
             priv.implementHypervisor.mux(ctrlStage(sl.keys.ENTRIES)(wayId).guest === forceGuest, True)
         }
       }
@@ -621,6 +623,7 @@ class MmuPlugin(var spec : MmuSpec,
             val storageLevelId = storage.self.p.levels.filter(_.id <= levelId).map(_.id).max
             val storageLevel = storage.sl.find(_.slp.id == storageLevelId).get
             val specLevel = storageLevel.level
+            val currentAsid = priv.implementHypervisor.mux(Mux(isTwoStage, vsatp.asid, satp.asid), satp.asid)
 
             val sel = storageOhReg(sid)
             storageLevel.write.mask                 := UIntToOh(storageLevel.allocId).andMask(sel).resized
@@ -628,6 +631,7 @@ class MmuPlugin(var spec : MmuSpec,
             storageLevel.write.data.valid           := True
             storageLevel.write.data.virtualAddress  := virtual(specLevel.virtualOffset + log2Up(storageLevel.slp.sets), widthOf(storageLevel.write.data.virtualAddress) bits)
             storageLevel.write.data.physicalAddress := (load.levelToPhysicalAddress(levelId) >> specLevel.virtualOffset).resized
+            if (asidWidth > 0) storageLevel.write.data.asid := currentAsid
             storageLevel.write.data.allowRead       := load.flags.R
             storageLevel.write.data.allowWrite      := load.flags.W && load.flags.D
             storageLevel.write.data.allowExecute    := load.flags.X

--- a/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
@@ -688,8 +688,8 @@ class MmuPlugin(var spec : MmuSpec,
       val guest = withGuestSfenceCheck generate RegInit(False)
       val force = RegInit(False)
 
-      val anyAsid = (asidWidth > 0).mux(asid === 0, True) || force
-      val anyAddress = address === 0
+      val anyAsid = (asidWidth > 0).mux(RegInit(False), True)
+      val anyAddress = RegInit(False)
       val query = MmuTlbStorageEntryQuery(
         address = address,
         asid    = asid,
@@ -703,6 +703,8 @@ class MmuPlugin(var spec : MmuSpec,
           busy := True
           asid := arbiter.io.output.asid.resized
           address := arbiter.io.output.address.resized
+          anyAddress := arbiter.io.output.anyAddress || arbiter.io.output.force
+          if(asidWidth > 0) anyAsid := arbiter.io.output.anyAsid
           force := arbiter.io.output.force
           if (withGuestSfenceCheck) guest := arbiter.io.output.guest
         }

--- a/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
@@ -676,9 +676,9 @@ class MmuPlugin(var spec : MmuSpec,
       val asid = RegInit(B(0, asidWidth bits))
       val address = RegInit(U(0, MIXED_WIDTH bits))
       val guest = withGuestSfenceCheck generate RegInit(False)
-      val both = withGuestSfenceCheck generate RegInit(False)
+      val force = RegInit(False)
 
-      val anyAsid = (asidWidth > 0).mux(asid === 0, True)
+      val anyAsid = (asidWidth > 0).mux(asid === 0, True) || force
       val anyAddress = address === 0
       val query = MmuTlbStorageEntryQuery(
         address = address,
@@ -693,10 +693,8 @@ class MmuPlugin(var spec : MmuSpec,
           busy := True
           asid := arbiter.io.output.asid.resized
           address := arbiter.io.output.address.resized
-          if (withGuestSfenceCheck) {
-            guest := arbiter.io.output.guest
-            both := arbiter.io.output.both
-          }
+          force := arbiter.io.output.force
+          if (withGuestSfenceCheck) guest := arbiter.io.output.guest
         }
       } otherwise {
         assert(HART_COUNT.get == 1)
@@ -705,7 +703,7 @@ class MmuPlugin(var spec : MmuSpec,
           val invalidateReadAddress = Mux(anyAddress, counter.resized, address(sl.lineRange))
           val mask = B(sl.ways.map(way => {
             val entry = way.readAsync(invalidateReadAddress)
-            entry.needFlush(query, anyAsid, anyAddress) || both
+            entry.needFlush(query, anyAsid, anyAddress) || force
           }))
           sl.write.mask := mask
           sl.write.address := invalidateReadAddress

--- a/src/main/scala/vexiiriscv/memory/Service.scala
+++ b/src/main/scala/vexiiriscv/memory/Service.scala
@@ -76,15 +76,22 @@ case class AddressTranslationRefill(storageWidth : Int) extends Bundle{
   rsp.payload.setName("bits")
 }
 
-case class AddressTranslationInvalidationCmd() extends Bundle {
+case class AddressTranslationInvalidationParam(
+  asidWidth: Int = 0,
+  requestAddress: Boolean = false
+)
+
+case class AddressTranslationInvalidationCmd(p: AddressTranslationInvalidationParam) extends Bundle {
   val hartId = HART_ID()
+  val asid = Bits(p.asidWidth bits)
+  val address = p.requestAddress generate MIXED_ADDRESS()
 }
 
 /**
  * Used by the TrapPlugin to ask the MmuPlugin to invalidate its TLB (on SFENCE.VMA / SATP updates)
  */
-case class AddressTranslationInvalidation() extends Bundle {
-  val cmd = Stream(AddressTranslationInvalidationCmd())
+case class AddressTranslationInvalidation(p: AddressTranslationInvalidationParam) extends Bundle {
+  val cmd = Stream(AddressTranslationInvalidationCmd(p))
 }
 
 /**
@@ -99,6 +106,7 @@ trait AddressTranslationService extends Area {
   def getStorageId(s : Any) : Int
   def getStorageIdWidth() : Int
   def getSignExtension(kind : AddressTranslationPortUsage, rawAddress : UInt) : Bool
+  def getInvalidationPortParam : AddressTranslationInvalidationParam
 
   val regionRetainer = Retainer()
 
@@ -113,7 +121,7 @@ trait AddressTranslationService extends Area {
   def newRefillPort() = refillPorts.addRet(AddressTranslationRefill(getStorageIdWidth()))
 
   val invalidationPorts = ArrayBuffer[AddressTranslationInvalidation]()
-  def newInvalidationPort() = invalidationPorts.addRet(AddressTranslationInvalidation())
+  def newInvalidationPort() = invalidationPorts.addRet(AddressTranslationInvalidation(getInvalidationPortParam))
 }
 
 case class AddressTranslationReq(

--- a/src/main/scala/vexiiriscv/memory/Service.scala
+++ b/src/main/scala/vexiiriscv/memory/Service.scala
@@ -83,10 +83,15 @@ case class AddressTranslationInvalidationParam(
 )
 
 case class AddressTranslationInvalidationCmd(p: AddressTranslationInvalidationParam) extends Bundle {
+  def withAnyAsid = p.asidWidth > 0
+  def withAnyAddress = p.requestAddress
+
   val hartId = HART_ID()
   val asid = Bits(p.asidWidth bits)
   val address = p.requestAddress generate MIXED_ADDRESS()
   val guest = p.requestGuest generate Bool()
+  val anyAddress = p.requestAddress generate Bool()
+  val anyAsid = withAnyAsid generate Bool()
   /* For reset */
   val force = Bool()
 }

--- a/src/main/scala/vexiiriscv/memory/Service.scala
+++ b/src/main/scala/vexiiriscv/memory/Service.scala
@@ -88,7 +88,7 @@ case class AddressTranslationInvalidationCmd(p: AddressTranslationInvalidationPa
 }
 
 /**
- * Used by the TrapPlugin to ask the MmuPlugin to invalidate its TLB (on SFENCE.VMA / SATP updates)
+ * Used by the TrapPlugin to ask the MmuPlugin to invalidate its TLB (on SFENCE.VMA)
  */
 case class AddressTranslationInvalidation(p: AddressTranslationInvalidationParam) extends Bundle {
   val cmd = Stream(AddressTranslationInvalidationCmd(p))

--- a/src/main/scala/vexiiriscv/memory/Service.scala
+++ b/src/main/scala/vexiiriscv/memory/Service.scala
@@ -78,13 +78,17 @@ case class AddressTranslationRefill(storageWidth : Int) extends Bundle{
 
 case class AddressTranslationInvalidationParam(
   asidWidth: Int = 0,
-  requestAddress: Boolean = false
+  requestAddress: Boolean = false,
+  requestGuest: Boolean = false
 )
 
 case class AddressTranslationInvalidationCmd(p: AddressTranslationInvalidationParam) extends Bundle {
   val hartId = HART_ID()
   val asid = Bits(p.asidWidth bits)
   val address = p.requestAddress generate MIXED_ADDRESS()
+  val guest = p.requestGuest generate Bool()
+  /* For match both guest and non-guest */
+  val both = p.requestGuest generate Bool()
 }
 
 /**

--- a/src/main/scala/vexiiriscv/memory/Service.scala
+++ b/src/main/scala/vexiiriscv/memory/Service.scala
@@ -87,8 +87,8 @@ case class AddressTranslationInvalidationCmd(p: AddressTranslationInvalidationPa
   val asid = Bits(p.asidWidth bits)
   val address = p.requestAddress generate MIXED_ADDRESS()
   val guest = p.requestGuest generate Bool()
-  /* For match both guest and non-guest */
-  val both = p.requestGuest generate Bool()
+  /* For reset */
+  val force = Bool()
 }
 
 /**

--- a/src/main/scala/vexiiriscv/memory/ShadowMmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/ShadowMmuPlugin.scala
@@ -25,6 +25,11 @@ class ShadowMmuPlugin(var spec : MmuSpec,
   /* Second stage is always zero-extended */
   def getSignExtension(kind: AddressTranslationPortUsage, rawAddress: UInt) = False
 
+  override def getInvalidationPortParam = AddressTranslationInvalidationParam(
+    asidWidth       = 0,
+    requestAddress  = false
+  )
+
   val api = during build new Area{
     val fetchTranslationEnable = Bool()
     val lsuTranslationEnable = Bool()

--- a/src/main/scala/vexiiriscv/memory/ShadowMmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/ShadowMmuPlugin.scala
@@ -87,6 +87,7 @@ class ShadowMmuPlugin(var spec : MmuSpec,
     assert(storageSpecs.map(_.p.priority).distinct.size == storageSpecs.size, "MMU storages needs different priorities")
     // Implement the hardware for all the TLB storages
     val tlbGenerateParam = MmuTlbStorageEntryParam(
+      asidWidth   = 0,
       checkUser   = false,
       checkGuest  = false
     )

--- a/src/main/scala/vexiiriscv/memory/ShadowMmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/ShadowMmuPlugin.scala
@@ -27,7 +27,8 @@ class ShadowMmuPlugin(var spec : MmuSpec,
 
   override def getInvalidationPortParam = AddressTranslationInvalidationParam(
     asidWidth       = 0,
-    requestAddress  = false
+    requestAddress  = false,
+    requestGuest    = false,
   )
 
   val api = during build new Area{

--- a/src/main/scala/vexiiriscv/memory/ShadowMmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/ShadowMmuPlugin.scala
@@ -125,8 +125,15 @@ class ShadowMmuPlugin(var spec : MmuSpec,
       val read = for (sl <- storage.sl) yield new Area {
         val readAddress = readStage(ps.req.PRE_ADDRESS)(sl.lineRange)
         for ((way, wayId) <- sl.ways.zipWithIndex) {
+          /* The shadow MMU should not enable the "ASID" and "GUEST" field of TLB */
+          val query = MmuTlbStorageEntryQuery(
+            address = hitsStage(ps.req.PRE_ADDRESS),
+            asid    = B(0),
+            guest   = False
+          )
+
           readStage(sl.keys.ENTRIES)(wayId) := way.readAsync(readAddress)
-          hitsStage(sl.keys.HITS_PRE_VALID)(wayId) := hitsStage(sl.keys.ENTRIES)(wayId).hit(hitsStage(ps.req.PRE_ADDRESS))
+          hitsStage(sl.keys.HITS_PRE_VALID)(wayId) := hitsStage(sl.keys.ENTRIES)(wayId).hit(query)
           ctrlStage(sl.keys.HITS)(wayId) := ctrlStage(sl.keys.HITS_PRE_VALID)(wayId) && ctrlStage(sl.keys.ENTRIES)(wayId).valid
         }
       }

--- a/src/main/scala/vexiiriscv/memory/ShadowMmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/ShadowMmuPlugin.scala
@@ -95,6 +95,7 @@ class ShadowMmuPlugin(var spec : MmuSpec,
     val tlbGenerateParam = MmuTlbStorageEntryParam(
       asidWidth   = 0,
       checkUser   = false,
+      checkGlobal = false,
       checkGuest  = false
     )
     val storages = for(ss <- storageSpecs) yield new MmuTlbStorage(spec, physicalWidth, tlbGenerateParam, ss)

--- a/src/main/scala/vexiiriscv/memory/StaticTranslationPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/StaticTranslationPlugin.scala
@@ -22,6 +22,11 @@ class StaticTranslationPlugin(var physicalWidth: Int, val translationLevel : Int
   override def getStorageId(s: Any): Int = 0
   override def getStorageIdWidth(): Int = 0
 
+  override def getInvalidationPortParam = AddressTranslationInvalidationParam(
+    asidWidth       = 0,
+    requestAddress  = false
+  )
+
   case class PortSpec(stages: Seq[NodeBaseApi],
                       req: AddressTranslationReq,
                       usage: AddressTranslationPortUsage,

--- a/src/main/scala/vexiiriscv/misc/TrapPlugin.scala
+++ b/src/main/scala/vexiiriscv/misc/TrapPlugin.scala
@@ -449,6 +449,8 @@ class TrapPlugin(val trapAt : Int, val recordHtinst : Boolean) extends FiberPlug
             invalidate.cmd.address := pending.state.tval.asUInt.resized
             invalidate.cmd.asid := pending.state.tval2.resized
             if (invalidate.p.requestGuest) invalidate.cmd.guest := pending.state.arg(0)
+            invalidate.cmd.anyAddress := pending.state.arg(1)
+            if (invalidate.cmd.withAnyAsid) invalidate.cmd.anyAsid := pending.state.arg(2)
 
             val invalidated = RegInit(False) setWhen(invalidate.cmd.fire)
             invalidate.cmd.valid setWhen(!invalidated)

--- a/src/main/scala/vexiiriscv/misc/TrapPlugin.scala
+++ b/src/main/scala/vexiiriscv/misc/TrapPlugin.scala
@@ -448,6 +448,10 @@ class TrapPlugin(val trapAt : Int, val recordHtinst : Boolean) extends FiberPlug
             invalidate.cmd.hartId := hartId
             invalidate.cmd.address := 0
             invalidate.cmd.asid := 0
+            if (invalidate.p.requestGuest) {
+              invalidate.cmd.guest := False
+              invalidate.cmd.both := True
+            }
 
             val invalidated = RegInit(False) setWhen(invalidate.cmd.fire)
             invalidate.cmd.valid setWhen(!invalidated)
@@ -639,6 +643,11 @@ class TrapPlugin(val trapAt : Int, val recordHtinst : Boolean) extends FiberPlug
                     atsPorts.invalidate.cmd.valid := True
                     atsPorts.invalidate.cmd.address := pending.state.tval.asUInt.resized
                     atsPorts.invalidate.cmd.asid := pending.state.tval2.resized
+                    if (atsPorts.invalidate.p.requestGuest) {
+                      atsPorts.invalidate.cmd.guest := pending.state.arg(0)
+                      atsPorts.invalidate.cmd.both := False
+                    }
+
                     when(atsPorts.invalidate.cmd.ready) {
                       goto(JUMP)
                     }

--- a/src/main/scala/vexiiriscv/misc/TrapPlugin.scala
+++ b/src/main/scala/vexiiriscv/misc/TrapPlugin.scala
@@ -446,16 +446,14 @@ class TrapPlugin(val trapAt : Int, val recordHtinst : Boolean) extends FiberPlug
             val invalidate = ats.newInvalidationPort()
             invalidate.cmd.valid := False
             invalidate.cmd.hartId := hartId
-            invalidate.cmd.address := 0
-            invalidate.cmd.asid := 0
-            if (invalidate.p.requestGuest) {
-              invalidate.cmd.guest := False
-              invalidate.cmd.both := True
-            }
+            invalidate.cmd.address := pending.state.tval.asUInt.resized
+            invalidate.cmd.asid := pending.state.tval2.resized
+            if (invalidate.p.requestGuest) invalidate.cmd.guest := pending.state.arg(0)
 
             val invalidated = RegInit(False) setWhen(invalidate.cmd.fire)
             invalidate.cmd.valid setWhen(!invalidated)
             resetToRunConditions += invalidated
+            invalidate.cmd.force := !invalidated
           }
 
           val satsPorts = sats.mayNeedRedo generate new Area{
@@ -641,13 +639,6 @@ class TrapPlugin(val trapAt : Int, val recordHtinst : Boolean) extends FiberPlug
                 is(TrapReason.SFENCE_VMA) {
                   if(ats.mayNeedRedo) {
                     atsPorts.invalidate.cmd.valid := True
-                    atsPorts.invalidate.cmd.address := pending.state.tval.asUInt.resized
-                    atsPorts.invalidate.cmd.asid := pending.state.tval2.resized
-                    if (atsPorts.invalidate.p.requestGuest) {
-                      atsPorts.invalidate.cmd.guest := pending.state.arg(0)
-                      atsPorts.invalidate.cmd.both := False
-                    }
-
                     when(atsPorts.invalidate.cmd.ready) {
                       goto(JUMP)
                     }

--- a/src/main/scala/vexiiriscv/misc/TrapPlugin.scala
+++ b/src/main/scala/vexiiriscv/misc/TrapPlugin.scala
@@ -446,6 +446,8 @@ class TrapPlugin(val trapAt : Int, val recordHtinst : Boolean) extends FiberPlug
             val invalidate = ats.newInvalidationPort()
             invalidate.cmd.valid := False
             invalidate.cmd.hartId := hartId
+            invalidate.cmd.address := 0
+            invalidate.cmd.asid := 0
 
             val invalidated = RegInit(False) setWhen(invalidate.cmd.fire)
             invalidate.cmd.valid setWhen(!invalidated)
@@ -635,6 +637,8 @@ class TrapPlugin(val trapAt : Int, val recordHtinst : Boolean) extends FiberPlug
                 is(TrapReason.SFENCE_VMA) {
                   if(ats.mayNeedRedo) {
                     atsPorts.invalidate.cmd.valid := True
+                    atsPorts.invalidate.cmd.address := pending.state.tval.asUInt.resized
+                    atsPorts.invalidate.cmd.asid := pending.state.tval2.resized
                     when(atsPorts.invalidate.cmd.ready) {
                       goto(JUMP)
                     }

--- a/src/main/scala/vexiiriscv/riscv/RegFile.scala
+++ b/src/main/scala/vexiiriscv/riscv/RegFile.scala
@@ -45,6 +45,10 @@ object IntRegFile extends RegfileSpec with AreaObject {
     key = key,
     resources = List(RD).map(this -> _)
   )
+  def TypeRS(key : MaskedLiteral) = SingleDecoding(
+    key = key,
+    resources = List(RS1, RS2).map(this -> _)
+  )
   def TypeUPC(key : MaskedLiteral) = SingleDecoding(
     key = key,
     resources = List(RD).map(this -> _) :+ PC_READ

--- a/src/main/scala/vexiiriscv/riscv/Rvh.scala
+++ b/src/main/scala/vexiiriscv/riscv/Rvh.scala
@@ -29,7 +29,7 @@ object Rvh extends AreaObject {
   val HSV_D              = TypeRSQ(M"0110111----------100000001110011")
 
   val HFENCE_GVMA        = TypeNone(M"0110001----------000000001110011")
-  val HFENCE_VVMA        = TypeNone(M"0010001----------000000001110011")
+  val HFENCE_VVMA        = TypeRS(M"0010001----------000000001110011")
 
   loadSpec(HLV_B)  = LoadSpec( 8,  true)
   loadSpec(HLV_H)  = LoadSpec(16,  true)

--- a/src/main/scala/vexiiriscv/riscv/Rvi.scala
+++ b/src/main/scala/vexiiriscv/riscv/Rvi.scala
@@ -159,7 +159,7 @@ object Rvi extends AreaObject {
 
   val FENCE              = TypeNone(M"-----------------000-----0001111")
   val FENCE_I            = TypeNone(M"-----------------001-----0001111")
-  val SFENCE_VMA         = TypeNone(M"0001001----------000000001110011")
+  val SFENCE_VMA         = TypeRS(M"0001001----------000000001110011")
 
   val FLUSH_DATA         = TypeNone(M"-------00000-----101-----0001111")
 


### PR DESCRIPTION
This PR add basic ASID and global bit support for the MMU and SFENCE.VMA/HFENCE.VVMA. It can be enabled by setting asidWidth > 0.