### PR TITLE
Add multiple core Zicbom support when using with cache

### DIFF
--- a/src/main/scala/vexiiriscv/Param.scala
+++ b/src/main/scala/vexiiriscv/Param.scala
@@ -1093,6 +1093,7 @@ class ParamSimple() {
       )
     }
     if(lsuL1Enable){
+      val needLlc = withRvcbm && (withRvcbmLlc || lsuL1Coherency)
       plugins += new LsuPlugin(
         timingParameter = withRvh match {
           case true => lsuHypervisorTiming
@@ -1105,7 +1106,7 @@ class ParamSimple() {
         storeBufferOps = lsuStoreBufferOps,
         softwarePrefetch = lsuSoftwarePrefetch,
         withCbm = withRvcbm,
-        withLlcFlush = withRvcbmLlc,
+        withLlcFlush = needLlc,
         pmpPortParameter = lsuL1PmpParam.offset(withRvh.toInt),
         translationStorageParameter = lsuTsp,
         translationPortParameter = withMmu match {
@@ -1123,7 +1124,7 @@ class ParamSimple() {
         wayCount       = lsuL1Ways,
         withBypass     = withLsuBypass,
         withCoherency  = lsuL1Coherency,
-        withCbm        = withRvcbm && !withRvcbmLlc,
+        withCbm        = withRvcbm && !needLlc,
         bootMemClear = bootMemClear,
         tagsReadAsync  = lsuL1TagsReadAsync,
         timingParameter = withRvh match {

--- a/src/main/scala/vexiiriscv/execute/lsu/LsuPlugin.scala
+++ b/src/main/scala/vexiiriscv/execute/lsu/LsuPlugin.scala
@@ -286,7 +286,8 @@ class LsuPlugin(var layer : LaneLayer,
     }
 
     val bus = master(LsuCachelessBus(busParam)).simPublic()
-    val llcBus = withLlcFlush generate master(FlushBus(FlushParam(Global.PHYSICAL_WIDTH, 0)))
+    val llcFlushAddressWidth = XLEN.get max Global.PHYSICAL_WIDTH.get
+    val llcBus = withLlcFlush generate master(FlushBus(FlushParam(llcFlushAddressWidth, 0)))
 
     accessRetainer.await()
     val l1 = LsuL1
@@ -1000,7 +1001,7 @@ class LsuPlugin(var layer : LaneLayer,
         flushTokens := flushTokens - U(llcFlushBuffer.fire) + U(llcBus.rsp.fire)
 
         llcFlushBuffer.valid := isValid && SEL && !lsuTrap && !isCancel && (l1.CLEAN || l1.INVALID)
-        llcFlushBuffer.address := l1.PHYSICAL_ADDRESS
+        llcFlushBuffer.address := l1.PHYSICAL_ADDRESS.resized
 
         val redo = (!llcFlushBuffer.ready || flushFull) && (l1.CLEAN || l1.INVALID)
         when(redo) {

--- a/src/main/scala/vexiiriscv/soc/litex/Soc.scala
+++ b/src/main/scala/vexiiriscv/soc/litex/Soc.scala
@@ -14,7 +14,7 @@ import spinal.lib.bus.amba4.axilite.sim.{AxiLite4ReadOnlySlaveAgent, AxiLite4Wri
 import spinal.lib.bus.misc.args.{PeriphSpecs, PeriphTilelinkFiber}
 import spinal.lib.bus.misc.{AddressMapping, SizeMapping}
 import spinal.lib.bus.tilelink
-import spinal.lib.bus.tilelink.coherent.{CacheFiber, HubFiber, SelfFLush}
+import spinal.lib.bus.tilelink.coherent.{CacheFiber, FlushArbiter, FlushParam, HubFiber, SelfFLush}
 import spinal.lib.bus.tilelink.{coherent, fabric}
 import spinal.lib.bus.tilelink.fabric.Node
 import spinal.lib.com.eth.sg.{MacSgFiber, MacSgFiberSpec, MacSgParam}
@@ -31,10 +31,10 @@ import spinal.lib.misc.{InterruptNode, InterruptCtrlFiber}
 import spinal.lib.sim.SparseMemory
 import spinal.lib.{AnalysisUtils, Delay, Flow, ResetCtrlFiber, StreamPipe, master, memPimped, slave, traversableOncePimped}
 import spinal.lib.system.tag.{MemoryConnection, MemoryEndpoint, MemoryEndpointTag, MemoryTransferTag, MemoryTransfers, PMA, VirtualEndpoint}
-import vexiiriscv.{Global, ParamSimple}
+import vexiiriscv.ParamSimple
 import vexiiriscv.compat.{EnforceSyncRamPhase, MultiPortWritesSymplifier}
 import vexiiriscv.execute.ExecuteLanePlugin
-import vexiiriscv.execute.lsu.LsuL1Plugin
+import vexiiriscv.execute.lsu.{LsuL1Plugin, LsuPlugin}
 import vexiiriscv.fetch.{Fetch, FetchL1Plugin, FetchPipelinePlugin, PcPlugin}
 import vexiiriscv.misc.{PrivilegedPlugin, TrapPlugin}
 import vexiiriscv.prediction.GSharePlugin
@@ -461,6 +461,12 @@ class Soc(c : SocConfig) extends Component {
           (cBus << dma.filter.down).setDownConnection(a = StreamPipe.FULL)
         }
 
+        val llcLsuPlugins = vexiis.flatMap(_.plugins.collect {
+          case p : LsuPlugin if p.withLlcFlush => p
+        })
+        assert(llcLsuPlugins.isEmpty || withL2, "Hub-only coherent Zicbom is unsupported; enable L2 so CBO can use the coherent CacheFiber FlushBus.")
+        val flushParam = llcLsuPlugins.nonEmpty generate FlushParam(vexiiParam.physicalWidth, log2Up(llcLsuPlugins.size))
+
         val hub = (withCoherency && !withL2) generate new Area {
           val hub = new HubFiber()
           hub.up << cBus
@@ -470,7 +476,7 @@ class Soc(c : SocConfig) extends Component {
         }
 
         val l2 = (withCoherency && withL2) generate new Area {
-          val cache = new CacheFiber(withCtrl = false)
+          val cache = new CacheFiber(withCtrl = false, flushBusParam = flushParam)
           cache.parameter.cacheWays = l2Ways
           cache.parameter.cacheBytes = l2Bytes
           cache.parameter.selfFlush = selfFlush
@@ -482,6 +488,19 @@ class Soc(c : SocConfig) extends Component {
           cache.up.setUpConnection(a = StreamPipe.FULL, c = StreamPipe.FULL, d = StreamPipe.FULL)
           cache.down.setDownConnection(d = StreamPipe.S2M)
           cache.down.forceDataWidth(mainDataWidth)
+          if(llcLsuPlugins.nonEmpty) {
+            val arbiter = new FlushArbiter(flushParam, llcLsuPlugins.size)
+            cache.flush.cmd << arbiter.io.output.cmd
+            arbiter.io.output.rsp << cache.flush.rsp
+
+            Fiber build new Area {
+              val llcBuses = llcLsuPlugins.map(_.logic.llcBus)
+              for((input, bus) <- (arbiter.io.inputs, llcBuses).zipped) {
+                input.cmd << bus.cmd
+                bus.rsp << input.rsp
+              }
+            }
+          }
           mBus << cache.down
         }
 

--- a/src/main/scala/vexiiriscv/soc/litex/Soc.scala
+++ b/src/main/scala/vexiiriscv/soc/litex/Soc.scala
@@ -465,7 +465,8 @@ class Soc(c : SocConfig) extends Component {
           case p : LsuPlugin if p.withLlcFlush => p
         })
         assert(llcLsuPlugins.isEmpty || withL2, "Hub-only coherent Zicbom is unsupported; enable L2 so CBO can use the coherent CacheFiber FlushBus.")
-        val flushParam = llcLsuPlugins.nonEmpty generate FlushParam(vexiiParam.physicalWidth, log2Up(llcLsuPlugins.size))
+        val llcFlushAddressWidth = vexiiParam.xlen max vexiiParam.physicalWidth
+        val flushParam = llcLsuPlugins.nonEmpty generate FlushParam(llcFlushAddressWidth, log2Up(llcLsuPlugins.size))
 
         val hub = (withCoherency && !withL2) generate new Area {
           val hub = new HubFiber()

--- a/src/test/scala/vexiiriscv/tester/Regression.scala
+++ b/src/test/scala/vexiiriscv/tester/Regression.scala
@@ -161,7 +161,7 @@ class Regression extends MultithreadedFunSuite(sys.env.getOrElse("VEXIIRISCV_REG
   dimensions += new Dimensions[ParamSimple]("cbm") {
     override def getRandomPosition(state : ParamSimple, random: Random): String = {
       if(!state.lsuL1Enable) return ""
-      List("", state.lsuL1Coherency.mux("--with-rvZcbm-llc", "--with-rvZcbm")).randomPick(random)
+      List("", "--with-rvZcbm").randomPick(random)
     }
   }
 


### PR DESCRIPTION
With recently SpinalHDL update, we already have the flushable cache support. So the VexiiRiscv now can enable zicbom in multiple core mode when enabling cache.

Note: Quote #139 as it improve the current implementation