### PR TITLE
fpu: fix FP compare treating subnormal operand as zero (feq/fle/flt)

### DIFF
--- a/src/main/scala/vexiiriscv/execute/fpu/FpuCmpPlugin.scala
+++ b/src/main/scala/vexiiriscv/execute/fpu/FpuCmpPlugin.scala
@@ -102,7 +102,7 @@ class FpuCmpPlugin(val layer : LaneLayer,
 
       val bothZero = insert(RS1_FP.isZero && RS2_FP.isZero)
       val expEqual = insert(RS1_FP.exponent === RS2_FP.exponent)
-      val rs1Equal = insert(RS1_FP.sign === RS2_FP.sign && expEqual && RS1_FP.mantissa === RS2_FP.mantissa)
+      val rs1Equal = insert(RS1_FP.sign === RS2_FP.sign && expEqual && RS1_FP.mantissa === RS2_FP.mantissa && RS1_FP.mode === RS2_FP.mode)
       val rs1ExpSmaller = insert(RS1_FP.exponent < RS2_FP.exponent)
       val rs1MantissaSmaller = insert(RS1_FP.mantissa < RS2_FP.mantissa)
 


### PR DESCRIPTION
Fixes #158

## Problem

FP comparisons (`feq.s`/`fle.s`/`flt.s`, and the `.d` forms) treat a **subnormal** operand as
**zero**, so a comparison between zero and a subnormal returns the wrong result:

| Comparison | operands | before | correct (IEEE / Spike) |
|---|---|---|---|
| `feq.s s1,f4,f6` | `+0.0`, `+subnormal (0x00400000)` | **1** | 0 |
| `fle.s s1,f4,f6` | `−0.0 (0x80000000)`, `−subnormal (0x80400000)` | **1** | 0 |

## Root cause

`FpuCmpPlugin`'s `rs1Equal` compared `sign`, `exponent` and `mantissa` but **not** the recoded
`FloatMode`:

```scala
val rs1Equal = insert(RS1_FP.sign === RS2_FP.sign && expEqual && RS1_FP.mantissa === RS2_FP.mantissa)
```

Subnormals are recoded to `NORMAL` with an extended exponent. For inputs such as `0x00400000` the
recoded `exponent`+`mantissa` coincide with those of zero (`mode = ZERO`), so `rs1Equal` reported
equality across differing modes and `CMP_RESULT` took the EQUAL branch (→ 1).

## Fix

Add a mode-equality term so operands with different modes are never treated as equal (diagnosis and
one-line fix by @Dolu1990 in #158):

```scala
val rs1Equal = insert(RS1_FP.sign === RS2_FP.sign && expEqual && RS1_FP.mantissa === RS2_FP.mantissa && RS1_FP.mode === RS2_FP.mode)
```

This can only *remove* spurious equalities: two numerically-equal FP values always share the same
mode, so no legitimate comparison changes.

## How it was found / reproduced

Coverage-guided lock-step fuzzing (rv64gc programs vs Spike/RVLS). Minimal repro (M-mode,
`mstatus.FS` on, `fcsr=0`, `fpuIgnoreSubnormal=false`):

```asm
    li      t0, 0x80000000
    fmv.w.x f4, t0            # -0.0
    li      t0, 0x80400000
    fmv.w.x f6, t0            # -subnormal
    fle.s   s1, f4, f6        # was 1, correct 0
```

Maintainer confirmed the patch makes the reported test pass.
