### PR TITLE
Add AIA/IMSIC simulation support to the TestBench

### DIFF
--- a/src/main/scala/vexiiriscv/Param.scala
+++ b/src/main/scala/vexiiriscv/Param.scala
@@ -610,6 +610,7 @@ class ParamSimple() {
     if (withMmu) r += s"asid$asidWidth"
     if (withIterativeShift) r += "isft"
     if (extension.withDiv) r += s"d${divRadix}${divImpl}${if(divArea)"Area" else ""}"
+    if (privParam.withImsic) r += s"if${privParam.imsicInterrupts}gf${privParam.guestExternalInterruptFiles}"
     if (privParam.withDebug) r += s"pdbg"
     if (privParam.withExternalInterrupt) r += "nei"
     if (embeddedJtagTap) r += s"jtagt"
@@ -668,6 +669,7 @@ class ParamSimple() {
     opt[Unit]("with-sxaia") action { (v, c) => addISA("smaia", "ssaia") }
     opt[Int]("imsic-interrupt-number") action { (v, c) => privParam.imsicInterrupts = v }
     opt[Int]("guest-external-interrupt-file-number") action { (v, c) => privParam.guestExternalInterruptFiles = v }
+    opt[Unit]("without-external-interrupt") action { (v, c) => privParam.withExternalInterrupt = false }
     opt[Unit]("with-whiteboxer-outputs") action { (v, c) => withWhiteboxerOutputs = true }
     opt[Unit]("with-hart-id-input") action { (v, c) => withHartIdInput = true }
     opt[Unit]("with-hart-id-input-defaulted") action { (v, c) => privParam.withHartIdInputDefaulted = true }

--- a/src/main/scala/vexiiriscv/Param.scala
+++ b/src/main/scala/vexiiriscv/Param.scala
@@ -611,6 +611,7 @@ class ParamSimple() {
     if (withIterativeShift) r += "isft"
     if (extension.withDiv) r += s"d${divRadix}${divImpl}${if(divArea)"Area" else ""}"
     if (privParam.withDebug) r += s"pdbg"
+    if (privParam.withExternalInterrupt) r += "nei"
     if (embeddedJtagTap) r += s"jtagt"
     if (embeddedJtagInstruction) r += s"jtagi"
     r.mkString("_")

--- a/src/main/scala/vexiiriscv/misc/ImsicPlugin.scala
+++ b/src/main/scala/vexiiriscv/misc/ImsicPlugin.scala
@@ -9,6 +9,8 @@ import vexiiriscv.execute.CsrAccessPlugin
 import vexiiriscv.riscv.{CSR, IndirectCSR}
 import vexiiriscv.riscv.Riscv._
 
+import scala.collection.mutable
+
 class ImsicPlugin(val p: PrivilegedParam) extends FiberPlugin {
   val logic = during setup new Area {
     val cap = host[CsrAccessPlugin]
@@ -118,23 +120,31 @@ class ImsicPlugin(val p: PrivilegedParam) extends FiberPlugin {
 
         api.readWrite(file.threshold, indirectApi.csrFilter(IndirectCSR.eithreshold, ireg))
 
-        val eidelivery = RegInit(U(0x40000000, XLEN bits))
-        val eideliveryFilter = indirectApi.csrFilter(IndirectCSR.eidelivery, ireg)
-        api.read(eidelivery, eideliveryFilter)
-        api.onWrite(eideliveryFilter, true) {
-          eidelivery := cap.bus.write.bits.mux(
-            0x40000000 -> U(0x40000000, XLEN bits),
+        def deliveryArbiter(external: Option[Bool]): Bool = {
+          val deliveryCode = mutable.ArrayBuffer(
             0x1 -> U(1, XLEN bits),
             default -> U(0, XLEN bits)
           )
-        }
-
-        def deliveryArbiter(aplicTarget: Bool): Bool = {
-          eidelivery.mux(
+          val deliveryInterrupt = mutable.ArrayBuffer(
             1 -> file.interrupt,
-            0x40000000 -> aplicTarget,
             default -> False
           )
+          var defaultValue = 0
+          external match {
+            case Some(ext) => {
+              defaultValue = 0x40000000
+              deliveryCode += 0x40000000 -> U(0x40000000, XLEN bits)
+              deliveryInterrupt += 0x40000000 -> ext
+            }
+            case _ =>
+          }
+          val eidelivery = RegInit(U(defaultValue, XLEN bits))
+          val eideliveryFilter = indirectApi.csrFilter(IndirectCSR.eidelivery, ireg)
+          api.read(eidelivery, eideliveryFilter)
+          api.onWrite(eideliveryFilter, true) {
+            eidelivery := cap.bus.write.bits.muxList(deliveryCode)
+          }
+          eidelivery.muxList(deliveryInterrupt)
         }
       }
 

--- a/src/main/scala/vexiiriscv/misc/PrivilegedPlugin.scala
+++ b/src/main/scala/vexiiriscv/misc/PrivilegedPlugin.scala
@@ -657,7 +657,7 @@ class PrivilegedPlugin(val p : PrivilegedParam, val hartIds : Seq[Int]) extends 
         val imsic = p.withImsic generate imsicPlugin.logic.harts(hartId).m
 
         val ip = new api.Csr(CSR.MIP) {
-          val mext = if (p.withImsic) imsic.deliveryArbiter(int.m.external) else int.m.external
+          val mext = if (p.withImsic) imsic.deliveryArbiter(Some(int.m.external)) else int.m.external
 
           val meip = RegNext(mext) init (False)
           val mtip = RegNext(int.m.timer) init (False)
@@ -955,7 +955,7 @@ class PrivilegedPlugin(val p : PrivilegedParam, val hartIds : Seq[Int]) extends 
         val imsic = p.withImsic generate imsicPlugin.logic.harts(hartId).s
 
         val ip = new Area {
-          val sext = if (p.withImsic) imsic.deliveryArbiter(int.s.external) else int.s.external
+          val sext = if (p.withImsic) imsic.deliveryArbiter(Some(int.s.external)) else int.s.external
 
           val seipSoft = RegInit(False)
           val seipInput = RegNext(sext)

--- a/src/main/scala/vexiiriscv/misc/PrivilegedPlugin.scala
+++ b/src/main/scala/vexiiriscv/misc/PrivilegedPlugin.scala
@@ -42,7 +42,8 @@ object PrivilegedParam{
     injectedInterruptWidth = 6,
     debugTriggers  = 0,
     debugTriggersLsu = false,
-    withHartIdInputDefaulted = false
+    withHartIdInputDefaulted = false,
+    withExternalInterrupt = true,
   )
 }
 
@@ -76,7 +77,8 @@ case class PrivilegedParam(var withSupervisor : Boolean,
                            var imsicInterrupts: Int,
                            var injectedInterruptWidth: Int,
                            var guestExternalInterruptFiles: Int,
-                           var withHartIdInputDefaulted : Boolean){
+                           var withHartIdInputDefaulted : Boolean,
+                           var withExternalInterrupt: Boolean){
   def withImsic = imsicInterrupts > 0
   def withGuestImsic = withImsic && guestExternalInterruptFiles > 0
   def externalInterruptPriorityWidth = log2Up(imsicInterrupts)
@@ -94,6 +96,7 @@ case class PrivilegedParam(var withSupervisor : Boolean,
 
     /* IMSIC check */
     assert((imsicInterrupts == 0) || (isPow2(imsicInterrupts) && imsicInterrupts >= 64 && imsicInterrupts <= 2048))
+    assert(withExternalInterrupt || withImsic)
     assert(guestExternalInterruptFiles < 64)
     if (withHypervisor && withSsaia) {
       assert(injectedInterruptWidth >= 6 && injectedInterruptWidth <= 12)
@@ -207,10 +210,10 @@ class PrivilegedPlugin(val p : PrivilegedParam, val hartIds : Seq[Int]) extends 
         val m = new Area {
           val timer = Verilator.public(in Bool())
           val software = Verilator.public(in Bool())
-          val external = Verilator.public(in Bool())
+          val external = p.withExternalInterrupt generate Verilator.public(in Bool())
         }
         val s = p.withSupervisor generate new Area {
-          val external = Verilator.public(in Bool())
+          val external = p.withExternalInterrupt generate Verilator.public(in Bool())
         }
         val u = p.withUserTrap generate new Area {
           val external = Verilator.public(in Bool())
@@ -657,7 +660,8 @@ class PrivilegedPlugin(val p : PrivilegedParam, val hartIds : Seq[Int]) extends 
         val imsic = p.withImsic generate imsicPlugin.logic.harts(hartId).m
 
         val ip = new api.Csr(CSR.MIP) {
-          val mext = if (p.withImsic) imsic.deliveryArbiter(Some(int.m.external)) else int.m.external
+          val fromExternalCtrl = p.withExternalInterrupt.option(int.m.external)
+          val mext = if (p.withImsic) imsic.deliveryArbiter(fromExternalCtrl) else fromExternalCtrl.get
 
           val meip = RegNext(mext) init (False)
           val mtip = RegNext(int.m.timer) init (False)
@@ -955,7 +959,8 @@ class PrivilegedPlugin(val p : PrivilegedParam, val hartIds : Seq[Int]) extends 
         val imsic = p.withImsic generate imsicPlugin.logic.harts(hartId).s
 
         val ip = new Area {
-          val sext = if (p.withImsic) imsic.deliveryArbiter(Some(int.s.external)) else int.s.external
+          val fromExternalCtrl = p.withExternalInterrupt.option(int.s.external)
+          val sext = if (p.withImsic) imsic.deliveryArbiter(fromExternalCtrl) else fromExternalCtrl.get
 
           val seipSoft = RegInit(False)
           val seipInput = RegNext(sext)

--- a/src/main/scala/vexiiriscv/soc/litex/SocSim.scala
+++ b/src/main/scala/vexiiriscv/soc/litex/SocSim.scala
@@ -253,7 +253,7 @@ object SocSim extends App{
 
     val onPbusSim = simPeripheral generate new Area {
       val axi = dut.system.patcher.pBus
-      val emu = new PeripheralEmulator(0x10000000, null, null) {
+      val emu = new PeripheralEmulator(null, null) {
         override def getClintTime() = simTime()/10000
       }
       new AxiLite4ReadOnlySlaveAgent(axi.ar, axi.r, dut.litexCd){
@@ -261,7 +261,7 @@ object SocSim extends App{
           super.doRead(addr)
           axi.r.payload.data.randomize()
           val data = Array.fill[Byte](axi.config.bytePerWord)(0)
-          emu.access(false, addr.toLong, data)
+          emu.access(false, addr.toLong - 0x10000000, data)
           axi.r.payload.data #= data
         }
       }
@@ -271,7 +271,7 @@ object SocSim extends App{
           axi.r.payload.data.randomize()
           val buffer = Array.fill[Byte](axi.config.bytePerWord)(0)
           buffer(0) = data.toByte
-          emu.access(true, addr.toLong, buffer)
+          emu.access(true, addr.toLong - 0x10000000, buffer)
         }
       }
     }

--- a/src/main/scala/vexiiriscv/test/ImsicPeripheralEmulator.scala
+++ b/src/main/scala/vexiiriscv/test/ImsicPeripheralEmulator.scala
@@ -1,0 +1,91 @@
+package vexiiriscv.test
+
+import spinal.core.{ClockDomain, UInt}
+import spinal.core.sim._
+import spinal.lib.Stream
+import spinal.lib.bus.misc.SizeMapping
+import spinal.lib.misc.aia.{ImsicFileInfo, ImsicMapping, ImsicTrigger}
+import spinal.lib.sim.StreamDriver
+
+import scala.collection.mutable
+
+case class ImsicSimFile(base: BigInt, info: ImsicFileInfo, trigger: Stream[UInt], cd: ClockDomain) {
+  val (driver, queue) = StreamDriver.queue(trigger, cd)
+  driver.transactionDelay = () => 0
+  driver.delay = 0
+
+  def enqueue(bytes: Array[Byte]): Unit = {
+    val bytesCopy = bytes.clone()
+    queue.enqueue((payload: UInt) => payload #= bytesCopy)
+  }
+}
+
+class ImsicPeripheralEmulator(val localMapping: ImsicMapping, val files: Seq[ImsicSimFile]) extends EmulatedDevice {
+  import ImsicPeripheralEmulator._
+
+  def mappedSize: BigInt = localMapping.interruptFileHartSize
+  def addressMapping: SizeMapping = SizeMapping(files.head.base, mappedSize)
+
+  val registerSize = 4
+  val IP_LE = 0x0L
+  val IP_BE = 0x4L
+
+  override def access(write: Boolean, address: BigInt, data: Array[Byte]): Boolean = {
+    if (address % registerSize != 0) return true
+
+    if (!write) {
+      java.util.Arrays.fill(data, 0.toByte)
+      return false
+    }
+
+    if (data.length != registerSize) return true
+
+    val pageId = (address / ImsicTrigger.interruptFileSize).toInt
+    val pageOffset = (address % ImsicTrigger.interruptFileSize).toLong
+
+    files.lift(pageId).foreach { file =>
+      pageOffset match {
+        case IP_LE => file.enqueue(data)
+        case IP_BE => file.enqueue(data.reverse)
+        case _ =>
+      }
+    }
+
+    false
+  }
+}
+
+object ImsicPeripheralEmulator {
+  val machineLayout = new {
+    val base = 0x24000000L
+    val mapping = ImsicMapping(
+      interruptFileHartSize = ImsicTrigger.interruptFileSize,
+      interruptFileHartOffset = 0,
+      interruptFileGroupSize = 0,
+    )
+  }
+  val supervisorLayout = new {
+    val base = 0x28000000L
+    val mapping = ImsicMapping(
+      interruptFileHartSize = 64 * ImsicTrigger.interruptFileSize,
+      interruptFileHartOffset = 0,
+      interruptFileGroupSize = 0,
+    )
+  }
+
+  def build(base: BigInt, mapping: ImsicMapping, bindings: Seq[(ImsicFileInfo, Stream[UInt])], cd: ClockDomain): Seq[ImsicPeripheralEmulator] = {
+    val infos = bindings.map(_._1)
+    val calibratedPhysicalMapping = ImsicTrigger.mappingCalibrate(mapping, infos)
+    val harts = bindings.groupBy(_._1.hartId).values.map(_.sortBy(_._1.guestId)).toSeq
+      .sortBy(hart => ImsicTrigger.imsicGroupHartOffset(calibratedPhysicalMapping, hart.head._1))
+
+    harts.map { hart =>
+      val hartMapping = ImsicTrigger.mappingCalibrate(ImsicMapping(), hart.last._1.guestId, maxGroupHartId = 0, maxGroupId = 0)
+      val files = hart.map { case (info, trigger) =>
+        val offset = base + ImsicTrigger.imsicOffset(calibratedPhysicalMapping, info)
+        ImsicSimFile(offset, info, trigger, cd)
+      }
+      new ImsicPeripheralEmulator(hartMapping, files)
+    }
+  }
+}

--- a/src/main/scala/vexiiriscv/test/IoDeviceManager.scala
+++ b/src/main/scala/vexiiriscv/test/IoDeviceManager.scala
@@ -1,0 +1,27 @@
+package vexiiriscv.test
+
+import spinal.lib.bus.misc.{AddressMapping, SizeMapping}
+
+import scala.collection.mutable
+
+trait EmulatedDevice {
+  def access(write: Boolean, address: BigInt, data: Array[Byte]): Boolean
+}
+
+case class IoDeviceManager() {
+  case class DeviceEntry (mapping: AddressMapping, device: EmulatedDevice)
+
+  val devices = mutable.ArrayBuffer[DeviceEntry]()
+
+  def registerDevice(mapping: AddressMapping, device: EmulatedDevice) =
+    devices += DeviceEntry(mapping, device)
+
+  private def findEntry(address: Long): Option[DeviceEntry] = devices.find(_.mapping.hit(address))
+
+  def find(address: Long): Option[EmulatedDevice] = findEntry(address).map(_.device)
+
+  def hit(address: Long): Boolean = find(address).nonEmpty
+
+  def access(write: Boolean, address: Long, data: Array[Byte]): Boolean =
+    findEntry(address).map(e => e.device.access(write, address - e.mapping.lowerBound, data)).getOrElse(true)
+}

--- a/src/main/scala/vexiiriscv/test/PeripheralEmulator.scala
+++ b/src/main/scala/vexiiriscv/test/PeripheralEmulator.scala
@@ -14,7 +14,7 @@ import scala.collection.mutable.ArrayBuffer
  * - RISC-V CLINT
  * - Simulation pass/fail commands
  */
-abstract class PeripheralEmulator(offset : Long, mei : Bool, sei : Bool, msi : Bool = null, mti : Bool = null, cd : ClockDomain = null) {
+abstract class PeripheralEmulator(mei : Bool, sei : Bool, msi : Bool = null, mti : Bool = null, cd : ClockDomain = null) extends EmulatedDevice {
   val PUTC = 0
   val PUT_HEX = 0x8
   val CLINT_BASE = 0x10000
@@ -75,12 +75,11 @@ abstract class PeripheralEmulator(offset : Long, mei : Bool, sei : Bool, msi : B
   }
 
 
-  def access(write : Boolean, address : Long, data : Array[Byte]) : Boolean = {
-    val addressPatched = address - offset
+  def access(write : Boolean, address : BigInt, data : Array[Byte]) : Boolean = {
     if(write) {
       val raw = BigInt(data.map(_.toByte).reverse.toArray)
       val v = raw.toLong
-      addressPatched.toInt match {
+      address.toInt match {
         case PUTC => {
           val c = data(0).toChar
           print(c.toString match {
@@ -129,7 +128,7 @@ abstract class PeripheralEmulator(offset : Long, mei : Bool, sei : Bool, msi : B
         for (i <- 0 until data.size) data(i) = (that >> i*8).toByte
       }
       for(i <- 0 until data.size) data(i) = 0
-      addressPatched.toInt match {
+      address.toInt match {
         case IO_FAULT_ADDRESS => {
           simRandom.nextBytes(data)
           return true;

--- a/src/main/scala/vexiiriscv/test/PeripheralEmulator.scala
+++ b/src/main/scala/vexiiriscv/test/PeripheralEmulator.scala
@@ -90,8 +90,14 @@ abstract class PeripheralEmulator(offset : Long, mei : Bool, sei : Bool, msi : B
         }
         case PUT_HEX => print(data.reverse.map(v => f"$v%02x").mkString(""))
         case PUT_DEC => print(f"${BigInt(data.map(_.toByte).reverse.toArray)}%d")
-        case MACHINE_EXTERNAL_INTERRUPT_CTRL => mei #= data(0).toBoolean
-        case SUPERVISOR_EXTERNAL_INTERRUPT_CTRL => sei #= data(0).toBoolean
+        case MACHINE_EXTERNAL_INTERRUPT_CTRL => {
+          if (mei == null) return true
+          mei #= data(0).toBoolean
+        }
+        case SUPERVISOR_EXTERNAL_INTERRUPT_CTRL => {
+          if (sei == null) return true
+          sei #= data(0).toBoolean
+        }
         case CLINT_BASE => msi #= (data(0).toInt & 1).toBoolean
         case CLINT_CMP => {
           data.size match {

--- a/src/main/scala/vexiiriscv/test/WhiteboxerPlugin.scala
+++ b/src/main/scala/vexiiriscv/test/WhiteboxerPlugin.scala
@@ -338,9 +338,11 @@ class WhiteboxerPlugin(withOutputs : Boolean) extends FiberPlugin{
         for ((hart, hartId) <- priv.logic.harts.zipWithIndex) {
           checkers += new InterruptChecker(hartId, hart.int.m.timer,  7)
           checkers += new InterruptChecker(hartId, hart.int.m.software,  3)
-          checkers += new InterruptChecker(hartId, hart.int.m.external, 11)
-          if (priv.p.withSupervisor) {
-            checkers += new InterruptChecker(hartId, hart.int.s.external, 9)
+          if (priv.p.withExternalInterrupt) {
+            checkers += new InterruptChecker(hartId, hart.int.m.external, 11)
+            if (priv.p.withSupervisor) {
+              checkers += new InterruptChecker(hartId, hart.int.s.external, 9)
+            }
           }
         }
         def check(): Unit = {

--- a/src/main/scala/vexiiriscv/tester/TestBench.scala
+++ b/src/main/scala/vexiiriscv/tester/TestBench.scala
@@ -24,7 +24,7 @@ import vexiiriscv.fetch.{FetchCachelessPlugin, FetchL1Plugin, PcService}
 import vexiiriscv.misc.{EmbeddedRiscvJtag, PrivilegedPlugin}
 import vexiiriscv.riscv.Riscv
 import vexiiriscv.test.konata.Backend
-import vexiiriscv.test.{IoDeviceManager, PeripheralEmulator, VexiiRiscvProbe}
+import vexiiriscv.test.{ImsicPeripheralEmulator, IoDeviceManager, PeripheralEmulator, VexiiRiscvProbe}
 
 import java.io.{File, IOException, PrintWriter}
 import java.net.{ServerSocket, Socket}
@@ -32,6 +32,7 @@ import java.nio.ByteBuffer
 import java.util.Scanner
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import vexiiriscv.misc.PrivilegedParam.base
 
 /**
  * This is the main VexiiRiscv testbench, you can invoke it from command line and is based on the TestOptions class
@@ -75,6 +76,19 @@ object TestBench extends App {
         override def isExecutable: Boolean = true
       }
     )
+    def imsicRegion(addressMapping: SizeMapping) = new PmaRegion {
+      override def mapping: AddressMapping = addressMapping
+      override def transfers: MemoryTransfers = M2sTransfers(
+        get = SizeRange(4),
+        putFull = SizeRange(4)
+      )
+      override def isMain: Boolean = false
+      override def isExecutable: Boolean = false
+    }
+    if (param.privParam.withImsic) {
+      regions += imsicRegion(SizeMapping(0x24000000L, param.hartCount * 0x1000L))
+      if (param.privParam.withSupervisor) regions += imsicRegion(SizeMapping(0x28000000L, param.hartCount * 0x40000L))
+    }
     ret.foreach{
       case p: FetchCachelessPlugin => p.regions.load(regions)
       case p: LsuCachelessPlugin => p.regions.load(regions)
@@ -328,23 +342,38 @@ class TestOptions {
     cd.onSamplings {
       host.logic.rdtime #= probe.cycle
     }
-    if (host.p.withImsic) {
-      priv.m.imsic.trigger.valid #= false
-      priv.m.imsic.trigger.payload #= 0
-      if (host.p.withSupervisor) {
-        priv.s.imsic.trigger.valid #= false
-        priv.s.imsic.trigger.payload #= 0
-      }
-      if (host.p.withHypervisor && host.p.withGuestImsic) priv.h.imsic.triggers.foreach(trigger => {
-        trigger.valid #= false
-        trigger.payload #= 0
-      })
-    }
     peripheral.withStdIn = withStdIn
 
     val manager = IoDeviceManager()
 
     manager.registerDevice(SizeMapping(0x10000000L, 0x10000000L), peripheral)
+
+    if (host.p.withImsic) {
+      val layout = ImsicPeripheralEmulator.machineLayout
+      val mImsic = ImsicPeripheralEmulator.build(
+        base      = layout.base,
+        mapping   = layout.mapping,
+        bindings  = Seq(priv.m.imsic.file.asImsicFileInfo() -> priv.m.imsic.trigger),
+        cd        = cd
+      )
+      mImsic.foreach(device => manager.registerDevice(device.addressMapping, device))
+
+      if (host.p.withSupervisor) {
+        val guests = (host.p.withHypervisor && host.p.withGuestImsic).mux(
+          priv.h.imsic.files.zip(priv.h.imsic.triggers).map { case (file, trigger) => file.asImsicFileInfo() -> trigger },
+          Seq.empty
+        )
+        val bindings = Seq(priv.s.imsic.file.asImsicFileInfo() -> priv.s.imsic.trigger) ++ guests
+        val layout = ImsicPeripheralEmulator.supervisorLayout
+        val sImsic = ImsicPeripheralEmulator.build(
+          base      = layout.base,
+          mapping   = layout.mapping,
+          bindings  = bindings,
+          cd        = cd
+        )
+        sImsic.foreach(device => manager.registerDevice(device.addressMapping, device))
+      }
+    }
 
     dut.host.get[LsuPlugin].filter(_.withLlcFlush).map{p =>
       val bus = p.logic.llcBus
@@ -355,7 +384,6 @@ class TestOptions {
         rspQueue._2.enqueue {p => }
       }
     }
-
 
     var forceProbe = Option.empty[Long => Unit]
 

--- a/src/main/scala/vexiiriscv/tester/TestBench.scala
+++ b/src/main/scala/vexiiriscv/tester/TestBench.scala
@@ -24,7 +24,7 @@ import vexiiriscv.fetch.{FetchCachelessPlugin, FetchL1Plugin, PcService}
 import vexiiriscv.misc.{EmbeddedRiscvJtag, PrivilegedPlugin}
 import vexiiriscv.riscv.Riscv
 import vexiiriscv.test.konata.Backend
-import vexiiriscv.test.{PeripheralEmulator, VexiiRiscvProbe}
+import vexiiriscv.test.{IoDeviceManager, PeripheralEmulator, VexiiRiscvProbe}
 
 import java.io.{File, IOException, PrintWriter}
 import java.net.{ServerSocket, Socket}
@@ -321,7 +321,7 @@ class TestOptions {
     val priv = host.hart(0)
     val mei = host.p.withExternalInterrupt generate priv.int.m.external
     val sei = (host.p.withSupervisor && host.p.withExternalInterrupt) generate priv.int.s.external
-    val peripheral = new PeripheralEmulator(0x10000000, mei, sei, msi = priv.int.m.software, mti = priv.int.m.timer, cd = cd){
+    val peripheral = new PeripheralEmulator(mei, sei, msi = priv.int.m.software, mti = priv.int.m.timer, cd = cd){
       override def getClintTime(): BigInt = probe.cycle
       cmb.mem = mem
     }
@@ -342,7 +342,9 @@ class TestOptions {
     }
     peripheral.withStdIn = withStdIn
 
+    val manager = IoDeviceManager()
 
+    manager.registerDevice(SizeMapping(0x10000000L, 0x10000000L), peripheral)
 
     dut.host.get[LsuPlugin].filter(_.withLlcFlush).map{p =>
       val bus = p.logic.llcBus
@@ -473,7 +475,7 @@ class TestOptions {
 
     def doRead(address : Long, bytes : Int, dst : Array[Byte], offset : Int, io : Boolean): Boolean = {
       if (io) {
-        peripheral.access(false, address, dst)
+        manager.access(false, address, dst)
       } else {
         mem.readBytes(address, bytes, dst, offset)
         false
@@ -482,7 +484,7 @@ class TestOptions {
 
     def doWrite(address : Long, src : Array[Byte], io : Boolean): Boolean = {
       if (io) {
-        peripheral.access(true, address, src)
+        manager.access(true, address, src)
       } else {
         mem.write(address, src)
         false
@@ -541,17 +543,18 @@ class TestOptions {
             val byteOffset = Integer.numberOfTrailingZeros(mask)
             val size = Integer.numberOfTrailingZeros((~mask) >> byteOffset)
             val addr = (bus.ADR.toLong << addressShift) + byteOffset
-            val io = addr >= 0x10000000 && addr < 0x20000000
-            if(bus.WE.toBoolean){
+            val io = manager.hit(addr)
+            val error = if(bus.WE.toBoolean) {
               val bytes = bus.DAT_MOSI.toBytes.drop(byteOffset).take(size)
               doWrite(addr, bytes, io)
             } else {
               val bytes = new Array[Byte](bus.config.dataWidth/8)
-              doRead(addr, size, bytes, byteOffset, io)
+              val error = doRead(addr, size, bytes, byteOffset, io)
               val data = BigInt(1, bytes.reverse)
               bus.DAT_MISO #= data
+              error
             }
-            bus.ERR #= addr < 0x10000000
+            bus.ERR #= error || addr < 0x10000000
             bus.ACK #= true
           } else {
             bus.ACK #= false
@@ -840,8 +843,3 @@ class TestOptions {
     }
   }
 }
-
-
-
-
-

--- a/src/main/scala/vexiiriscv/tester/TestBench.scala
+++ b/src/main/scala/vexiiriscv/tester/TestBench.scala
@@ -319,7 +319,9 @@ class TestOptions {
 
     val host = dut.host[PrivilegedPlugin]
     val priv = host.hart(0)
-    val peripheral = new PeripheralEmulator(0x10000000, priv.int.m.external, (priv.int.s != null) generate priv.int.s.external, msi = priv.int.m.software, mti = priv.int.m.timer, cd = cd){
+    val mei = host.p.withExternalInterrupt generate priv.int.m.external
+    val sei = (host.p.withSupervisor && host.p.withExternalInterrupt) generate priv.int.s.external
+    val peripheral = new PeripheralEmulator(0x10000000, mei, sei, msi = priv.int.m.software, mti = priv.int.m.timer, cd = cd){
       override def getClintTime(): BigInt = probe.cycle
       cmb.mem = mem
     }

--- a/src/main/scala/vexiiriscv/tester/TilelinkTestBench.scala
+++ b/src/main/scala/vexiiriscv/tester/TilelinkTestBench.scala
@@ -262,7 +262,7 @@ object TlTbSim extends App{
       tracerFile.foreach(_.loadBin(offset, file))
     }
 
-    val peripheral = new PeripheralEmulator(0, null, null, null, null, cd = dut.mainResetCtrl.cd) {
+    val peripheral = new PeripheralEmulator(null, null, null, null, cd = dut.mainResetCtrl.cd) {
       override def getClintTime(): BigInt = 0
       val onBus = bind(dut.main.peripheral.eBus.node.bus, dut.main.peripheral.eBus.node.clockDomain)
     }


### PR DESCRIPTION
It is hard to check AIA related function as it is complex and require lots of external controller (See litex integration). This PR add an initial TestBench support for the VexiiRiscv.

The design of this PR is divided into three parts:
1. Add a new generation option to allow generate VexiiRiscv without external interrupt line. This is useful for simulation as when enable IMSIC, the interrupt is mainly come from IMSIC instead of the external interrupt line.
2. Add a `IoDeviceManager` to simpify the management of the IO device.
3. Add a new simulated IMSIC device `ImsicPeripheralEmulator`,

Behavior mismatch:
There is a behavior mismatch between TestBench and expected RTL. The write to IMSIC in RTL should return after the interrupt is received by the IMSIC File. However, the TestBench return immediately after the check. This should be safe as the MSI is always an async thing. And the design of IMSIC supports buffer between the bus and the file to reduce the soc bus pressure.

Note: 
1. No rvls support because the upstream PR https://github.com/riscv-software-src/riscv-isa-sim/pull/2342 is still under review. I will add rvls support after it is merged. And also no baremetal test as both sail and ACT has no test for this.. 
3. For linux test, although it is better to add some regression test for the AIA/IMSIC. I found it is hard to add a devicetree in a extensive way, because it is much better to reuse the supervisor blob for the test. As for some preparation, I seek for some suggestion for the test improvement. (Maybe add a new script for DTB generation separately?)