### PR TITLE
Mask reserved hgatp PPN bits

### DIFF
--- a/src/main/scala/vexiiriscv/memory/ShadowMmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/ShadowMmuPlugin.scala
@@ -68,7 +68,10 @@ class ShadowMmuPlugin(var spec : MmuSpec,
       val ppn =  Reg(UInt(ppnWidth bits))  init(0)
     }
 
-    csr.readWrite(CSR.HGATP, hgatp.vmidOffset -> hgatp.vmid, 0 -> hgatp.ppn)
+    csr.readWrite(CSR.HGATP,
+      hgatp.vmidOffset -> hgatp.vmid,
+      2 -> hgatp.ppn(hgatp.ppnWidth-1 downto 2)
+    )
     csr.read(CSR.HGATP, hgatp.modeOffset -> hgatp.mode)
     csr.allowHostCsr(CSR.HGATP, !priv.logic.harts(0).m.status.tvm || priv.isMachine(0))
 


### PR DESCRIPTION
`hgatp.PPN[1:0]` were writable and used as an address. Leave them unmapped so they read as zero.

Verification: `sbt compile`.