### PR TITLE
Support widened guest physical addresses

### DIFF
--- a/src/main/scala/vexiiriscv/Param.scala
+++ b/src/main/scala/vexiiriscv/Param.scala
@@ -816,7 +816,7 @@ class ParamSimple() {
     (extension.withRvh && withMmu) match {
       case false => plugins += new vexiiriscv.memory.StaticTranslationPlugin(physicalWidth, 1)
       case true => plugins += new vexiiriscv.memory.ShadowMmuPlugin(
-        spec = if (xlen == 32) MmuSpec.sv32 else MmuSpec.sv39,
+        spec = if (xlen == 32) MmuSpec.sv32x4 else MmuSpec.sv39x4,
         physicalWidth = physicalWidth,
         vmidWidth = 0 /* TODO */
       )

--- a/src/main/scala/vexiiriscv/execute/lsu/LsuCachelessPlugin.scala
+++ b/src/main/scala/vexiiriscv/execute/lsu/LsuCachelessPlugin.scala
@@ -224,7 +224,7 @@ class LsuCachelessPlugin(var layer : LaneLayer,
     val onAddress1 = new addressCtrl1.Area {
       val request = AddressTranslationReq(
         /* TODO: this should be a real physical with */
-        PRE_ADDRESS    = insert(tpk.TRANSLATED.resize(Global.MIXED_WIDTH)),
+        PRE_ADDRESS    = insert(tpk.TRANSLATED),
         LOAD           = LOAD,
         STORE          = STORE,
         EXECUTE        = EXECUTE,

--- a/src/main/scala/vexiiriscv/execute/lsu/LsuPlugin.scala
+++ b/src/main/scala/vexiiriscv/execute/lsu/LsuPlugin.scala
@@ -608,7 +608,7 @@ class LsuPlugin(var layer : LaneLayer,
       val LOAD_MMU = insert(LOAD || CLEAN || INVALIDATE)
       val request = AddressTranslationReq(
         /* TODO: this should be a real physical with */
-        PRE_ADDRESS    = insert(tpk.TRANSLATED.resize(Global.MIXED_WIDTH)),
+        PRE_ADDRESS    = insert(tpk.TRANSLATED),
         LOAD           = LOAD_MMU,
         STORE          = STORE,
         EXECUTE        = EXECUTE,

--- a/src/main/scala/vexiiriscv/fetch/FetchCachelessPlugin.scala
+++ b/src/main/scala/vexiiriscv/fetch/FetchCachelessPlugin.scala
@@ -119,7 +119,7 @@ class FetchCachelessPlugin(var wordWidth : Int,
 
     val onAddress1 = new pp.Fetch(addressAt + 1) {
       val request = AddressTranslationReq(
-        PRE_ADDRESS    = insert(tpk.TRANSLATED.resize(Fetch.WORD_PC.getWidth bits)),
+        PRE_ADDRESS    = insert(tpk.TRANSLATED),
         LOAD           = insert(False),
         STORE          = insert(False),
         EXECUTE        = insert(True),

--- a/src/main/scala/vexiiriscv/fetch/FetchL1Plugin.scala
+++ b/src/main/scala/vexiiriscv/fetch/FetchL1Plugin.scala
@@ -364,7 +364,7 @@ class FetchL1Plugin(var translationStorageParameter: Any,
 
     val onAddress1 = new pp.Fetch(readAt + 1) {
       val request = AddressTranslationReq(
-        PRE_ADDRESS    = insert(tpk.TRANSLATED.resize(Global.MIXED_WIDTH)),
+        PRE_ADDRESS    = insert(tpk.TRANSLATED),
         LOAD           = insert(False),
         STORE          = insert(False),
         EXECUTE        = insert(True),
@@ -681,4 +681,3 @@ class FetchL1Plugin(var translationStorageParameter: Any,
   val regions = Handle[ArrayBuffer[PmaRegion]]()
   val pmaBuilder = during build new PmaLogic(logic.ctrl.pmaPort, regions.filter(_.isExecutable))
 }
-

--- a/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
@@ -617,7 +617,7 @@ class MmuPlugin(var spec : MmuSpec,
             o.ae_final  := accessFault && load.leaf //Note so sure
             o.level := spec.levels.size - 1 - levelId
             o.address := Mux(translationFault,
-              Mux(shadowReadError, load.readed.asUInt, translatedAddress),
+              Mux(leafGuestFault, translatedAddress, Mux(shadowReadError, load.readed.asUInt, U(0))),
               translatedAddress
             ).resized
           }

--- a/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
@@ -78,6 +78,14 @@ object MmuSpec{
     satpMode   = 8,
     pteReserved = BigInt("FFC0000000000000", 16)
   )
+  val sv32x4 = sv32.copy(
+    levels = sv32.levels.updated(1, sv32.levels(1).copy(virtualWidth = 12)),
+    virtualWidth = 34
+  )
+  val sv39x4 = sv39.copy(
+    levels = sv39.levels.updated(2, sv39.levels(2).copy(virtualWidth = 11)),
+    virtualWidth = 41
+  )
 }
 
 case class MmuTlbStorageEntryParam(
@@ -230,6 +238,9 @@ class MmuPlugin(var spec : MmuSpec,
                 var physicalWidth : Int,
                 var asidWidth : Int,
                 var withGuestSfenceCheck : Boolean) extends FiberPlugin with GenericMmuPlugin{
+  override def requestWidth = spec.virtualWidth
+  override def translatedWidth = physicalWidth max withGuestSfenceCheck.mux(spec.virtualWidth + 2, physicalWidth)
+
   def withGlobalCheck = asidWidth > 0
 
   override def isShadowMmu : Boolean = false
@@ -280,7 +291,7 @@ class MmuPlugin(var spec : MmuSpec,
 
     accessLock.release()
 
-    def physCap(range : Range) = (range.high min physicalWidth-1) downto range.low
+    def physCap(range : Range) = (range.high min translatedWidth-1) downto range.low
 
     assert(HART_COUNT.get == 1)
     val satp = new Area {
@@ -341,7 +352,7 @@ class MmuPlugin(var spec : MmuSpec,
       checkGlobal = withGlobalCheck,
       checkGuest  = priv.implementHypervisor
     )
-    val storages = for(ss <- storageSpecs) yield new MmuTlbStorage(spec, physicalWidth, tlbGenerateParam, ss)
+    val storages = for(ss <- storageSpecs) yield new MmuTlbStorage(spec, translatedWidth, tlbGenerateParam, ss)
 
     assert(HART_COUNT.get == 1)
     val isMachine = priv.getPrivilege(0) === PrivilegeMode.M
@@ -502,7 +513,7 @@ class MmuPlugin(var spec : MmuSpec,
       })
 
       val load = new Area{
-        val address = Reg(UInt(PHYSICAL_WIDTH bits))
+        val address = Reg(UInt(translatedWidth bits))
 
         def cmd = accessBus.cmd
         val rspUnbuffered = accessBus.rsp
@@ -524,7 +535,7 @@ class MmuPlugin(var spec : MmuSpec,
                         reservedFault
         val levelToPhysicalAddress = List.fill(spec.levels.size)(UInt(spec.physicalWidth bits))
         val levelException = List.fill(spec.levels.size)(False)
-        val nextLevelBase = U(0, PHYSICAL_WIDTH bits)
+        val nextLevelBase = U(0, translatedWidth bits)
         for((level, id) <- spec.levels.zipWithIndex) {
           nextLevelBase(physCap(level.physicalRange)) := readed(level.entryRange).asUInt.resized
           levelToPhysicalAddress(id) := 0
@@ -576,11 +587,12 @@ class MmuPlugin(var spec : MmuSpec,
         val pteFault = (load.exception || load.levelException(levelId)) || (levelId == 0).mux(!load.leaf, False)
         val pteReadError = load.rsp.error(0)
         val shadowReadError = load.rsp.error(1)
-        val leafAccessFault = load.levelToPhysicalAddress(levelId).drop(physicalWidth) =/= 0 //levelToPhysicalAddress is used to emit fault when the final translated address it outside the range of the physical addresses
+        val leafGuestFault = isTwoStage && load.levelToPhysicalAddress(levelId).drop(spec.virtualWidth + 2) =/= 0
+        val leafAccessFault = !isTwoStage && load.levelToPhysicalAddress(levelId).drop(physicalWidth) =/= 0
         val pageFault = !shadowReadError && !pteReadError && pteFault
         val accessFault = pteReadError || (!pteFault && leafAccessFault)
-        val guestFault = shadowReadError && !pteReadError
-        val translationFault = pteFault || leafAccessFault
+        val guestFault = !pteReadError && (shadowReadError || (!pteFault && leafGuestFault))
+        val translationFault = pteFault || leafAccessFault || leafGuestFault
 
         def doneLogic() : Unit = {
           val translatedAddress = load.levelToPhysicalAddress(levelId)
@@ -599,13 +611,13 @@ class MmuPlugin(var spec : MmuSpec,
             o.bypass := False
             o.pageFault := pageFault
             o.accessFault := accessFault
-            o.guestFault := shadowReadError
+            o.guestFault := guestFault
             o.pf  := pageFault
             o.ae_ptw    := accessFault && !load.leaf
             o.ae_final  := accessFault && load.leaf //Note so sure
             o.level := spec.levels.size - 1 - levelId
             o.address := Mux(translationFault,
-              Mux(shadowReadError, load.readed.asUInt, U(0)),
+              Mux(shadowReadError, load.readed.asUInt, translatedAddress),
               translatedAddress
             ).resized
           }

--- a/src/main/scala/vexiiriscv/memory/Service.scala
+++ b/src/main/scala/vexiiriscv/memory/Service.scala
@@ -23,8 +23,8 @@ case class AddressTranslationRefillCmdPerm() extends Bundle{
   val execute = Bool()
 }
 
-case class AddressTranslationRefillCmd(storageWidth : Int) extends Bundle{
-  val address = MIXED_ADDRESS()
+case class AddressTranslationRefillCmd(storageWidth : Int, addressWidth : Int) extends Bundle{
+  val address = UInt(addressWidth bits)
   /*
    * For first-stage MMU:
    *    false : this request is a one-stage translation.
@@ -41,7 +41,7 @@ case class AddressTranslationRefillCmd(storageWidth : Int) extends Bundle{
   val permission = AddressTranslationRefillCmdPerm()
 }
 
-case class AddressTranslationRefillRsp() extends Bundle{
+case class AddressTranslationRefillRsp(addressWidth : Int) extends Bundle{
   val pageFault, accessFault, guestFault = Bool()
 
   val bypass = Bool()
@@ -56,11 +56,11 @@ case class AddressTranslationRefillRsp() extends Bundle{
   val hx  = Bool()
 
   val pte = new Bundle{
-    val ppn =  UInt(PHYSICAL_WIDTH - 12 bits)
+    val ppn = UInt(addressWidth - 12 bits)
     val flags = MmuEntryFlags()
   }
 
-  val address = UInt(PHYSICAL_WIDTH bits)
+  val address = UInt(addressWidth bits)
 
   val level = UInt(2 bits)
 }
@@ -68,9 +68,9 @@ case class AddressTranslationRefillRsp() extends Bundle{
 /**
  * Interface used by the TrapPlugin to ask the MMU's page walker to do work
  */
-case class AddressTranslationRefill(storageWidth : Int) extends Bundle{
-  val cmd = Stream(AddressTranslationRefillCmd(storageWidth))
-  val rsp = Stream(AddressTranslationRefillRsp())
+case class AddressTranslationRefill(storageWidth : Int, requestWidth : Int, translatedWidth : Int) extends Bundle{
+  val cmd = Stream(AddressTranslationRefillCmd(storageWidth, requestWidth))
+  val rsp = Stream(AddressTranslationRefillRsp(translatedWidth))
 
   cmd.payload.setName("bits")
   rsp.payload.setName("bits")
@@ -109,6 +109,8 @@ case class AddressTranslationInvalidation(p: AddressTranslationInvalidationParam
 trait AddressTranslationService extends Area {
   def isShadowMmu : Boolean
   def mayNeedRedo : Boolean
+  def requestWidth : Int
+  def translatedWidth : Int
   val storageLock = Retainer()
   val portsLock = Retainer()
   def newStorage(pAny: Any, pmuEventId : Int): Any
@@ -127,7 +129,7 @@ trait AddressTranslationService extends Area {
                          storageSpec: Any): AddressTranslationRsp
 
   val refillPorts = ArrayBuffer[AddressTranslationRefill]()
-  def newRefillPort() = refillPorts.addRet(AddressTranslationRefill(getStorageIdWidth()))
+  def newRefillPort() = refillPorts.addRet(AddressTranslationRefill(getStorageIdWidth(), requestWidth, translatedWidth))
 
   val invalidationPorts = ArrayBuffer[AddressTranslationInvalidation]()
   def newInvalidationPort() = invalidationPorts.addRet(AddressTranslationInvalidation(getInvalidationPortParam))
@@ -145,13 +147,13 @@ case class AddressTranslationReq(
 class AddressTranslationRsp(s : AddressTranslationService, val wayCount : Int) extends Area {
   val keys = new Area {
     // setName("MMU")
-    val TRANSLATED = Payload(PHYSICAL_ADDRESS)
+    val TRANSLATED = Payload(UInt(s.translatedWidth bits))
     val HAZARD = Payload(Bool())
     val REFILL = Payload(Bool())
     val PAGE_FAULT = Payload(Bool())
     val ACCESS_FAULT = Payload(Bool())
     val WAYS_OH  = Payload(Bits(wayCount bits))
-    val WAYS_PHYSICAL  = Payload(Vec.fill(wayCount)(PHYSICAL_ADDRESS()))
+    val WAYS_PHYSICAL  = Payload(Vec.fill(wayCount)(UInt(s.translatedWidth bits)))
     val BYPASS_TRANSLATION = Payload(Bool())
     val ADDRESS_EXTENSION = Payload(Bool())
   }
@@ -217,7 +219,8 @@ case class TranslatedDBusAccess(requestGuest : Boolean) extends Bundle {
 }
 
 case class TranslatedDBusAccessCmd(requestGuest : Boolean) extends Bundle {
-  val address = Global.PHYSICAL_ADDRESS()
+  val addressWidth = Global.PHYSICAL_WIDTH.get max requestGuest.mux(Global.VIRTUAL_WIDTH.get + 2, Global.PHYSICAL_WIDTH.get)
+  val address = UInt(addressWidth bits)
   val guest = requestGuest generate Bool()
   val size = UInt(2 bits)
 }

--- a/src/main/scala/vexiiriscv/memory/ShadowMmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/ShadowMmuPlugin.scala
@@ -21,6 +21,8 @@ class ShadowMmuPlugin(var spec : MmuSpec,
                       var physicalWidth : Int,
                       var vmidWidth : Int) extends FiberPlugin with GenericMmuPlugin{
   override def isShadowMmu : Boolean = true
+  override def requestWidth = spec.virtualWidth
+  override def translatedWidth = physicalWidth
 
   /* Second stage is always zero-extended */
   def getSignExtension(kind: AddressTranslationPortUsage, rawAddress: UInt) = False
@@ -198,7 +200,7 @@ class ShadowMmuPlugin(var spec : MmuSpec,
       val CMD, RSP, REFILL, DONE = List.fill(spec.levels.size)(new State)
 
       val busy = !isActive(IDLE)
-      val virtual = Reg(UInt(MIXED_WIDTH bits))
+      val virtual = Reg(UInt(requestWidth bits))
 
       setEntry(IDLE)
 

--- a/src/main/scala/vexiiriscv/memory/StaticTranslationPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/StaticTranslationPlugin.scala
@@ -18,6 +18,8 @@ import scala.collection.mutable.ArrayBuffer
 class StaticTranslationPlugin(var physicalWidth: Int, val translationLevel : Int = 0) extends FiberPlugin with AddressTranslationService {
   override def isShadowMmu : Boolean = translationLevel != 0
   override def mayNeedRedo: Boolean = false
+  override def requestWidth = physicalWidth
+  override def translatedWidth = physicalWidth
   override def newStorage(pAny: Any, pmuStorageId : Int): Any = { }
   override def getStorageId(s: Any): Int = 0
   override def getStorageIdWidth(): Int = 0

--- a/src/main/scala/vexiiriscv/memory/TranslatedDBusAccessPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/TranslatedDBusAccessPlugin.scala
@@ -104,7 +104,7 @@ class TranslatedDBusAccessPlugin() extends FiberPlugin with TranslatedDBusAccess
               trsp.error(0)       := atsPort.rsp.accessFault
               goto(IDLE)
             } otherwise {
-              address             := atsPort.rsp.address
+              address             := atsPort.rsp.address.resized
               goto(CMD)
             }
           }
@@ -113,7 +113,7 @@ class TranslatedDBusAccessPlugin() extends FiberPlugin with TranslatedDBusAccess
         CMD whenIsActive {
           when(cacheRefill === 0 && !cacheRefillAny) {
             cmd.valid     := True
-            cmd.address   := address
+            cmd.address   := address.resized
             cmd.size      := size
             when (cmd.ready) {
               goto(RSP)

--- a/src/test/scala/vexiiriscv/memory/GuestPhysicalWidthTest.scala
+++ b/src/test/scala/vexiiriscv/memory/GuestPhysicalWidthTest.scala
@@ -1,0 +1,10 @@
+package vexiiriscv.memory
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class GuestPhysicalWidthTest extends AnyFunSuite {
+  test("Sv39x4 accepts 41-bit guest physical addresses") {
+    assert(MmuSpec.sv39x4.virtualWidth == 41)
+    assert(MmuSpec.sv39x4.levels.last.virtualWidth == 11)
+  }
+}


### PR DESCRIPTION
VS-stage translations rejected or truncated legal GPAs at the host physical width.

Carry widened GPAs into the G stage. Use x4 root widths. Report over-width GPAs as guest-page faults.

Test: `sbt compile`
Test: focused Scala test
Test: RV64 H-extension RTL elaboration

Depends on #165.