### PR TITLE
Check first-stage permissions during TLB refill

### DIFF
--- a/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
@@ -468,6 +468,9 @@ class MmuPlugin(var spec : MmuSpec,
       val storageOhReg = Reg(Bits(storages.size bits))
       val storageEnable = Reg(Bool())
       val isTwoStage = Reg(Bool())
+      val forceGuest = Reg(Bool())
+      val applyMprv = Reg(Bool())
+      val permission = Reg(cloneOf(arbiter.io.output.permission))
       val isGlobal = Reg(Bool())
       val asid = Reg(Bits(asidWidth bits))
 
@@ -484,6 +487,9 @@ class MmuPlugin(var spec : MmuSpec,
           virtual := arbiter.io.output.address
           load.address := (ppn @@ spec.levels.last.vpn(arbiter.io.output.address) @@ U(0, log2Up(spec.entryBytes) bits)).resized
           isTwoStage := arbiter.io.output.indirect
+          forceGuest := arbiter.io.output.forceGuest
+          applyMprv := arbiter.io.output.applyMprv
+          permission := arbiter.io.output.permission
           isGlobal := False
           asid := priv.implementHypervisor.mux(
             Mux(arbiter.io.output.indirect, vsatp.asid, satp.asid),
@@ -572,6 +578,35 @@ class MmuPlugin(var spec : MmuSpec,
       o.pte.ppn := U(load.readed.dropLow(10)).resized
     }
 
+      val permissionCheck = new Area {
+        val effectivePrivilege = applyMprv.mux(
+          mprv.mux(mpp, priv.getPrivilege(0).asUInt.resize(2)),
+          priv.getPrivilege(0).asUInt.resize(2)
+        )
+        val isSupervisor = effectivePrivilege === PrivilegeMode.S
+        val isUser = effectivePrivilege === PrivilegeMode.U
+        val nominalSupervisor = priv.implementHypervisor.mux(
+          forceGuest.mux(priv.logic.harts(0).h.status.spvp, isSupervisor),
+          isSupervisor
+        )
+        val nominalUser = priv.implementHypervisor.mux(
+          forceGuest.mux(!priv.logic.harts(0).h.status.spvp, isUser),
+          isUser
+        )
+        val allowMxr = priv.implementHypervisor.mux(isTwoStage.mux(vsstatus.mxr, False), False) || status.mxr
+        val allowSum = priv.implementHypervisor.mux(isTwoStage.mux(vsstatus.sum, status.sum), status.sum)
+        val allowExecute = load.flags.X && !(load.flags.U && nominalSupervisor)
+        val allowRead = load.flags.R || allowMxr && load.flags.X
+        val allowWrite = load.flags.W && load.flags.D
+
+        val privilegeFault = (load.flags.U && nominalSupervisor && !allowSum) ||
+                             (!load.flags.U && nominalUser)
+        val readFault = permission.read && !allowRead
+        val writeFault = permission.write && !allowWrite
+        val executeFault = permission.execute && !allowExecute
+        val fault = privilegeFault || readFault || writeFault || executeFault
+      }
+
       val fetch = for((level, levelId) <- spec.levels.zipWithIndex) yield new Area{
         val pteFault = (load.exception || load.levelException(levelId)) || (levelId == 0).mux(!load.leaf, False)
         val pteReadError = load.rsp.error(0)
@@ -597,7 +632,7 @@ class MmuPlugin(var spec : MmuSpec,
 
           refillPorts.map(_.rsp).foreach { o =>
             o.bypass := False
-            o.pageFault := pageFault
+            o.pageFault := pageFault || (!translationFault && permissionCheck.fault)
             o.accessFault := accessFault
             o.guestFault := shadowReadError
             o.pf  := pageFault

--- a/src/main/scala/vexiiriscv/memory/Service.scala
+++ b/src/main/scala/vexiiriscv/memory/Service.scala
@@ -35,6 +35,9 @@ case class AddressTranslationRefillCmd(storageWidth : Int) extends Bundle{
    *    true  : this request is for implicit memory access.
    */
   val indirect = Bool()
+  /* Context used by first-stage leaf permission checks. */
+  val forceGuest = Bool()
+  val applyMprv = Bool()
   val storageId = UInt(storageWidth bits)
   val storageEnable = Bool()
 

--- a/src/main/scala/vexiiriscv/memory/TranslatedDBusAccessPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/TranslatedDBusAccessPlugin.scala
@@ -28,6 +28,8 @@ class TranslatedDBusAccessPlugin() extends FiberPlugin with TranslatedDBusAccess
       atsPort.cmd.valid               := False
       atsPort.cmd.address             := U(0)
       atsPort.cmd.indirect            := True
+      atsPort.cmd.forceGuest          := False
+      atsPort.cmd.applyMprv           := False
       atsPort.cmd.storageEnable       := False
       atsPort.cmd.storageId           := U(0)
       atsPort.cmd.permission.read     := True

--- a/src/main/scala/vexiiriscv/misc/TesterPlugin.scala
+++ b/src/main/scala/vexiiriscv/misc/TesterPlugin.scala
@@ -54,6 +54,11 @@ class TesterPlugin extends FiberPlugin{
     ptw.cmd.storageId := 0
     ptw.cmd.storageEnable := False
     if (priv.implementHypervisor) ptw.cmd.indirect := False
+    ptw.cmd.forceGuest := False
+    ptw.cmd.applyMprv := False
+    ptw.cmd.permission.read := True
+    ptw.cmd.permission.write := False
+    ptw.cmd.permission.execute := False
     ptw.rsp.ready := True
 
     val pending = CounterUpDown(4, ptw.cmd.fire, ptw.rsp.fire)

--- a/src/main/scala/vexiiriscv/misc/TrapPlugin.scala
+++ b/src/main/scala/vexiiriscv/misc/TrapPlugin.scala
@@ -505,6 +505,8 @@ class TrapPlugin(val trapAt : Int, val recordHtinst : Boolean) extends FiberPlug
             val isGuestRefill = pending.state.arg(2) || PrivilegeMode.isGuest(priv.getPrivilege(hartId)) || (csr.m.status.mprv && csr.m.status.mpv)
             refill.cmd.valid := False
             refill.cmd.indirect := isGuestRefill
+            refill.cmd.forceGuest := pending.state.arg(2)
+            refill.cmd.applyMprv := pending.state.arg(1 downto 0) =/= TrapArg.FETCH
             refill.cmd.permission.read := !pending.state.arg(1)
             refill.cmd.permission.write := pending.state.arg(0, 2 bits) === TrapArg.STORE
             refill.cmd.permission.execute := pending.state.arg(1)
@@ -532,6 +534,8 @@ class TrapPlugin(val trapAt : Int, val recordHtinst : Boolean) extends FiberPlug
             val refill = sats.newRefillPort()
             refill.cmd.valid := False
             refill.cmd.indirect := False
+            refill.cmd.forceGuest := False
+            refill.cmd.applyMprv := pending.state.arg(1 downto 0) =/= TrapArg.FETCH
             refill.cmd.permission.read := !pending.state.arg(1)
             refill.cmd.permission.write := pending.state.arg(0, 2 bits) === TrapArg.STORE
             refill.cmd.permission.execute := pending.state.arg(1)


### PR DESCRIPTION
First-stage PTE permission checks were only applied on TLB hits. A cold two-stage access could therefore refill the VS-stage translation and consult the G stage before noticing a VS-stage permission fault, making the exception cause depend on TLB residency.

Carry the access privilege context into the refill request and apply the same U/R/W/X, SUM, MXR, MPRV, plus SPVP checks to the leaf response. A first-stage permission fault now wins before a G-stage refill is attempted.

Verification: sbt compile; RV64 elaboration with and without the H extension; full-core Verilator probe. A simultaneous VS write-permission fault plus invalid G-stage mapping now reports store page fault (0x0f) for cold/warm/cold/warm runs. The control with a valid VS mapping plus invalid G-stage mapping remains store guest-page fault (0x17).