### PR TITLE
Fix MMU page fault check priority in TLB refill process

### DIFF
--- a/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
@@ -361,6 +361,40 @@ class MmuPlugin(var spec : MmuSpec,
       api.lsuTranslationEnable clearWhen (!mprv || priv.logic.harts(0).m.status.mpp === PrivilegeMode.M)
     }
 
+    case class PermissionCheckRequest(
+      isGuestAccess      : Bool,
+      forceGuest         : Bool,
+      effectivePrivilege : UInt,
+      requestRead        : Bool,
+      requestWrite       : Bool,
+      requestExecute     : Bool,
+      lineAllowExecute   : Bool,
+      lineAllowRead      : Bool,
+      lineAllowWrite     : Bool,
+      lineAllowUser      : Bool,
+    )
+
+    def permissionCheck(req: PermissionCheckRequest) = new Area {
+      import req._
+
+      val isSupervisor = effectivePrivilege === PrivilegeMode.S
+      val isUser = effectivePrivilege === PrivilegeMode.U
+      val nominalSupervisor = priv.implementHypervisor.mux(forceGuest.mux(priv.logic.harts(0).h.status.spvp, isSupervisor), isSupervisor)
+      val nominalUser = priv.implementHypervisor.mux(forceGuest.mux(!priv.logic.harts(0).h.status.spvp, isUser), isUser)
+
+      val allow_mxr     = priv.implementHypervisor.mux(isGuestAccess.mux(vsstatus.mxr, False), False) || status.mxr
+      val allow_sum     = priv.implementHypervisor.mux(isGuestAccess.mux(vsstatus.sum, status.sum), status.sum)
+      val allow_execute = lineAllowExecute && !(lineAllowUser && nominalSupervisor)
+      val allow_read    = lineAllowRead || allow_mxr && lineAllowExecute
+      val allow_write   = lineAllowWrite
+
+      val privCheck     = (lineAllowUser && nominalSupervisor && !allow_sum) ||
+                          (!lineAllowUser && nominalUser)
+      val readCheck     = requestRead && !allow_read
+      val writeCheck    = requestWrite && !allow_write
+      val executeCheck  = requestExecute && !allow_execute
+      val page_fault    = privCheck || readCheck || writeCheck || executeCheck
+    }
 
     // Implement the hardware of very MMU ports on their respective pipelines / storages
     val portSpecsSorted = portSpecs.sortBy(_.ss.p.priority).reverse
@@ -395,10 +429,6 @@ class MmuPlugin(var spec : MmuSpec,
           case LOAD_STORE => mprv.mux(mpp, priv.getPrivilege(0).asUInt.resize(2))
           case FETCH => priv.getPrivilege(0).asUInt.resize(2)
         }
-        val isSupervisor = effectivePrivilege === PrivilegeMode.S
-        val isUser = effectivePrivilege === PrivilegeMode.U
-        val nominalSupervisor = priv.implementHypervisor.mux(ps.req.FORCE_GUEST.mux(priv.logic.harts(0).h.status.spvp, isSupervisor), isSupervisor)
-        val nominalUser = priv.implementHypervisor.mux(ps.req.FORCE_GUEST.mux(!priv.logic.harts(0).h.status.spvp, isUser), isUser)
         val hits = Cat(storage.sl.map(s => ctrlStage(s.keys.HITS)))
         val entries = storage.sl.flatMap(s => ctrlStage(s.keys.ENTRIES))
         val hit = hits.orR
@@ -411,6 +441,21 @@ class MmuPlugin(var spec : MmuSpec,
         val lineAllowUser    = entriesMux(_.allowUser)
         val lineTranslated   = entriesMux(_.physicalAddressFrom(ps.req.PRE_ADDRESS))
 
+        val permReq = PermissionCheckRequest(
+          isGuestAccess       = isGuestAccess,
+          forceGuest          = ps.req.FORCE_GUEST,
+          effectivePrivilege  = effectivePrivilege,
+          requestRead         = ps.req.LOAD,
+          requestWrite        = ps.req.STORE,
+          requestExecute      = ps.req.EXECUTE,
+          lineAllowExecute    = lineAllowExecute,
+          lineAllowRead       = lineAllowRead,
+          lineAllowWrite      = lineAllowWrite,
+          lineAllowUser       = lineAllowUser,
+        )
+
+        val permRsp = permissionCheck(permReq)
+
         val requireMmuLockup  = CombInit(ps.usage match {
           case LOAD_STORE => ps.req.FORCE_GUEST.mux(vsatpValid, api.lsuTranslationEnable)
           case FETCH => api.fetchTranslationEnable
@@ -419,23 +464,10 @@ class MmuPlugin(var spec : MmuSpec,
 
         import ps.rsp.keys._
         when(requireMmuLockup) {
-          val allow_mxr     = priv.implementHypervisor.mux(isGuestAccess.mux(vsstatus.mxr, False), False) || status.mxr
-          val allow_sum     = priv.implementHypervisor.mux(isGuestAccess.mux(vsstatus.sum, status.sum), status.sum)
-          val allow_execute = lineAllowExecute && !(lineAllowUser && nominalSupervisor)
-          val allow_read    = lineAllowRead || allow_mxr && lineAllowExecute
-          val allow_write   = lineAllowWrite
-
-          val privCheck     = (lineAllowUser && nominalSupervisor && !allow_sum) ||
-                              (!lineAllowUser && nominalUser)
-          val readCheck     = ps.req.LOAD && !allow_read
-          val writeCheck    = ps.req.STORE && !allow_write
-          val executeCheck  = ps.req.EXECUTE && !allow_execute
-          val page_fault    = privCheck || readCheck || writeCheck || executeCheck
-
           HAZARD        := False
           REFILL        := !hit
           TRANSLATED    := lineTranslated
-          PAGE_FAULT    := page_fault
+          PAGE_FAULT    := permRsp.page_fault
           ACCESS_FAULT  := False
         } otherwise {
           HAZARD        := False
@@ -468,6 +500,8 @@ class MmuPlugin(var spec : MmuSpec,
       val storageOhReg = Reg(Bits(storages.size bits))
       val storageEnable = Reg(Bool())
       val isTwoStage = Reg(Bool())
+      val forceGuest = Reg(Bool())
+      val permission = Reg(cloneOf(arbiter.io.output.permission))
       val isGlobal = Reg(Bool())
       val asid = Reg(Bits(asidWidth bits))
 
@@ -484,6 +518,8 @@ class MmuPlugin(var spec : MmuSpec,
           virtual := arbiter.io.output.address
           load.address := (ppn @@ spec.levels.last.vpn(arbiter.io.output.address) @@ U(0, log2Up(spec.entryBytes) bits)).resized
           isTwoStage := arbiter.io.output.indirect
+          forceGuest := arbiter.io.output.forceGuest
+          permission := arbiter.io.output.permission
           isGlobal := False
           asid := priv.implementHypervisor.mux(
             Mux(arbiter.io.output.indirect, vsatp.asid, satp.asid),
@@ -539,6 +575,26 @@ class MmuPlugin(var spec : MmuSpec,
         }
       }
 
+      val permCheck = new Area {
+        val currentPrivilege = priv.getPrivilege(0).asUInt.resize(2)
+        val effectivePrivilege = permission.execute.mux(currentPrivilege, mprv.mux(mpp, currentPrivilege))
+        val req = PermissionCheckRequest(
+          isGuestAccess = isTwoStage,
+          forceGuest = forceGuest,
+          effectivePrivilege = effectivePrivilege,
+          requestRead = permission.read,
+          requestWrite = permission.write,
+          requestExecute = permission.execute,
+          lineAllowExecute = load.flags.X,
+          lineAllowRead = load.flags.R,
+          lineAllowWrite = load.flags.W && load.flags.D,
+          lineAllowUser = load.flags.U,
+        )
+
+        val rsp = permissionCheck(req)
+      }
+
+
       for (port <- refillPorts; rsp = port.rsp) {
         rsp.valid := False
         rsp.pageFault.assignDontCare()
@@ -581,6 +637,7 @@ class MmuPlugin(var spec : MmuSpec,
         val accessFault = pteReadError || (!pteFault && leafAccessFault)
         val guestFault = shadowReadError && !pteReadError
         val translationFault = pteFault || leafAccessFault
+        val permissionFault = permCheck.rsp.page_fault
 
         def doneLogic() : Unit = {
           val translatedAddress = load.levelToPhysicalAddress(levelId)
@@ -597,14 +654,14 @@ class MmuPlugin(var spec : MmuSpec,
 
           refillPorts.map(_.rsp).foreach { o =>
             o.bypass := False
-            o.pageFault := pageFault
+            o.pageFault := Mux(translationFault, pageFault, permissionFault)
             o.accessFault := accessFault
             o.guestFault := shadowReadError
             o.pf  := pageFault
             o.ae_ptw    := accessFault && !load.leaf
             o.ae_final  := accessFault && load.leaf //Note so sure
             o.level := spec.levels.size - 1 - levelId
-            o.address := Mux(translationFault,
+            o.address := Mux(translationFault || permissionFault,
               Mux(shadowReadError, load.readed.asUInt, U(0)),
               translatedAddress
             ).resized

--- a/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/MmuPlugin.scala
@@ -662,7 +662,7 @@ class MmuPlugin(var spec : MmuSpec,
             o.ae_final  := accessFault && load.leaf //Note so sure
             o.level := spec.levels.size - 1 - levelId
             o.address := Mux(translationFault || permissionFault,
-              Mux(shadowReadError, load.readed.asUInt, U(0)),
+              Mux(shadowReadError, load.readed.asUInt, load.address),
               translatedAddress
             ).resized
           }

--- a/src/main/scala/vexiiriscv/memory/Service.scala
+++ b/src/main/scala/vexiiriscv/memory/Service.scala
@@ -38,6 +38,13 @@ case class AddressTranslationRefillCmd(storageWidth : Int) extends Bundle{
   val storageId = UInt(storageWidth bits)
   val storageEnable = Bool()
 
+  /*
+   * This is used to track translation requrest from HLV/HSV.
+   * This signal is only valid for first-stage MMU, for second-stage
+   * MMU, it will be always false.
+   */
+  val forceGuest = Bool()
+
   val permission = AddressTranslationRefillCmdPerm()
 }
 

--- a/src/main/scala/vexiiriscv/memory/TranslatedDBusAccessPlugin.scala
+++ b/src/main/scala/vexiiriscv/memory/TranslatedDBusAccessPlugin.scala
@@ -28,6 +28,7 @@ class TranslatedDBusAccessPlugin() extends FiberPlugin with TranslatedDBusAccess
       atsPort.cmd.valid               := False
       atsPort.cmd.address             := U(0)
       atsPort.cmd.indirect            := True
+      atsPort.cmd.forceGuest          := False
       atsPort.cmd.storageEnable       := False
       atsPort.cmd.storageId           := U(0)
       atsPort.cmd.permission.read     := True

--- a/src/main/scala/vexiiriscv/misc/TesterPlugin.scala
+++ b/src/main/scala/vexiiriscv/misc/TesterPlugin.scala
@@ -53,6 +53,10 @@ class TesterPlugin extends FiberPlugin{
     ptw.cmd.address := address.value.asSInt.resize(widthOf(ptw.cmd.address)).asUInt
     ptw.cmd.storageId := 0
     ptw.cmd.storageEnable := False
+    ptw.cmd.forceGuest := False
+    ptw.cmd.permission.read := True
+    ptw.cmd.permission.write := False
+    ptw.cmd.permission.execute := False
     if (priv.implementHypervisor) ptw.cmd.indirect := False
     ptw.rsp.ready := True
 

--- a/src/main/scala/vexiiriscv/misc/TrapPlugin.scala
+++ b/src/main/scala/vexiiriscv/misc/TrapPlugin.scala
@@ -505,6 +505,7 @@ class TrapPlugin(val trapAt : Int, val recordHtinst : Boolean) extends FiberPlug
             val isGuestRefill = pending.state.arg(2) || PrivilegeMode.isGuest(priv.getPrivilege(hartId)) || (csr.m.status.mprv && csr.m.status.mpv)
             refill.cmd.valid := False
             refill.cmd.indirect := isGuestRefill
+            refill.cmd.forceGuest := pending.state.arg(2)
             refill.cmd.permission.read := !pending.state.arg(1)
             refill.cmd.permission.write := pending.state.arg(0, 2 bits) === TrapArg.STORE
             refill.cmd.permission.execute := pending.state.arg(1)
@@ -532,6 +533,7 @@ class TrapPlugin(val trapAt : Int, val recordHtinst : Boolean) extends FiberPlug
             val refill = sats.newRefillPort()
             refill.cmd.valid := False
             refill.cmd.indirect := False
+            refill.cmd.forceGuest := False
             refill.cmd.permission.read := !pending.state.arg(1)
             refill.cmd.permission.write := pending.state.arg(0, 2 bits) === TrapArg.STORE
             refill.cmd.permission.execute := pending.state.arg(1)

--- a/src/main/scala/vexiiriscv/misc/TrapPlugin.scala
+++ b/src/main/scala/vexiiriscv/misc/TrapPlugin.scala
@@ -776,8 +776,8 @@ class TrapPlugin(val trapAt : Int, val recordHtinst : Boolean) extends FiberPlug
                 atsPorts.refill.rsp.ready := True
                 pending.state.exception := True
                 if (priv.p.withHypervisor) when(atsPorts.isGuestRefill) {
-                  buffer.trap.tval2 := atsPorts.refill.rsp.address.dropLow(2).asBits.resized
                   when (atsPorts.refill.rsp.guestFault) {
+                    buffer.trap.tval2 := atsPorts.refill.rsp.address.dropLow(2).asBits.resized
                     buffer.trap.pseudoUop := (XLEN.get == 32).mux(0x00002000, 0x00003000)
                   }
                 }
@@ -828,7 +828,9 @@ class TrapPlugin(val trapAt : Int, val recordHtinst : Boolean) extends FiberPlug
               goto(JUMP) // improvement: shave one cycle
               when(satsPorts.refill.rsp.pageFault || satsPorts.refill.rsp.accessFault) {
                 pending.state.exception := True
-                buffer.trap.tval2 := satsPorts.refill.rsp.address.dropLow(2).asBits.resized
+                when (satsPorts.refill.rsp.pageFault) {
+                  buffer.trap.tval2 := satsPorts.refill.rsp.address.dropLow(2).asBits.resized
+                }
                 switch(satsPorts.refill.rsp.accessFault ## pending.state.arg(1 downto 0)){
                   def add(k : Int, v : Int) = is(k){pending.state.code := v}
                   add(TrapArg.FETCH | 4, CSR.MCAUSE_ENUM.INSTRUCTION_ACCESS_FAULT)


### PR DESCRIPTION
The improved version of #168 

This PR solves permission check error in G-stage refill process, which is a check miss in original refill process in ATS_RSP to SATS_RSP. As no permission check is performed, the PTW will think the VS-stage PTE is fine and trigger a bad check on G-stage PTE, which will not be performed if the VS-stage PTE is failed.

For vivado test on XCKU5P for gch build. only 4FF/4LUT is added, so I think adding a dedicated check is acceptable.

