### PR TITLE
Fix pattern match in DispatchPlugin

### DIFF
--- a/src/main/scala/vexiiriscv/schedule/DispatchPlugin.scala
+++ b/src/main/scala/vexiiriscv/schedule/DispatchPlugin.scala
@@ -175,7 +175,7 @@ class DispatchPlugin(var dispatchAt : Int,
       // Identify which RS are used by the pipeline
       val resources = ll.uops.keySet.flatMap(_.resources).distinctLinked
       val readAccess = rfaReads.filter(e => resources.exists {
-        case RfResource(_, e) => true
+        case RfResource(_, `e`._1) => true
         case _ => false
       }).values
 


### PR DESCRIPTION
The pattern match here matches every RfResource irrespective of RfAccess agreement, and the filter invariably returns true. I believe this is not the intended behavior.