### PR TITLE
Allow overriding the SpinalHDL selection via system properties

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,10 @@
-val spinalVersion = "dev"
-val spinalHdlFromSource = sys.env.getOrElse("SPINALHDL_FROM_SOURCE", "1") == "1"
-val spinalHdlPathEnabled = sys.env.contains("SPINALHDL_PATH")
-val spinalHdlPath = sys.env.getOrElse("SPINALHDL_PATH", "./ext/SpinalHDL")
+def spinalHdlOption(prop: String, env: String, default: String) =
+  sys.props.getOrElse(prop, sys.env.getOrElse(env, default))
+
+val spinalVersion = spinalHdlOption("spinalhdl.version", "SPINALHDL_VERSION", "dev")
+val spinalHdlFromSource = spinalHdlOption("spinalhdl.fromSource", "SPINALHDL_FROM_SOURCE", "1") == "1"
+val spinalHdlPathEnabled = sys.props.contains("spinalhdl.path") || sys.env.contains("SPINALHDL_PATH")
+val spinalHdlPath = spinalHdlOption("spinalhdl.path", "SPINALHDL_PATH", "./ext/SpinalHDL")
 
 def rootGen() = {
   var ret = (project in file(".")).settings(
@@ -13,7 +16,7 @@ def rootGen() = {
       crossScalaVersions := SpinalVersion.compilers,
       version := "2.0.0"
     )),
-    scalacOptions += s"-Xplugin:${new File((if(spinalHdlPathEnabled) spinalHdlPath else baseDirectory.value.getAbsolutePath + s"/ext/SpinalHDL") + s"/idslplugin/target/scala-${scalaVersion.value.split("\\.").dropRight(1).mkString(".")}/spinalhdl-idsl-plugin_${scalaVersion.value.split("\\.").dropRight(1).mkString(".")}-$spinalVersion.jar")}",
+    scalacOptions ++= (if (spinalHdlFromSource) Seq(s"-Xplugin:${new File((if(spinalHdlPathEnabled) spinalHdlPath else baseDirectory.value.getAbsolutePath + s"/ext/SpinalHDL") + s"/idslplugin/target/scala-${scalaVersion.value.split("\\.").dropRight(1).mkString(".")}/spinalhdl-idsl-plugin_${scalaVersion.value.split("\\.").dropRight(1).mkString(".")}-$spinalVersion.jar")}") else Nil),
     scalacOptions += s"-Xplugin-require:idsl-plugin",
     scalacOptions += "-language:reflectiveCalls",
     javaOptions += "-Xss16M",


### PR DESCRIPTION
SPINALHDL_FROM_SOURCE and SPINALHDL_PATH could only be set through the environment, and the SpinalHDL version was not configurable at all: it was hardcoded to "dev", which is not published to Maven Central. Turning SPINALHDL_FROM_SOURCE off therefore left the build asking for an artifact that cannot be resolved:

  com.github.spinalhdl:spinalhdl-core_2.12:dev  ->  404

Read all three from a JVM system property first, falling back to the existing environment variable and then to the previous default. This lets a downstream project pin the SpinalHDL it wants from a committed .sbtopts, without exporting anything into the environment. Defaults and environment variables behave exactly as before.

Also restrict the -Xplugin option to source builds. With a binary SpinalHDL the idsl plugin comes from the compilerPlugin dependency, while the option pointed into ext/SpinalHDL for a jar that nothing builds in that mode.