### PR TITLE
Fix wrong rs hazard logic

### DIFF
--- a/src/main/scala/vexiiriscv/schedule/DispatchPlugin.scala
+++ b/src/main/scala/vexiiriscv/schedule/DispatchPlugin.scala
@@ -266,7 +266,7 @@ class DispatchPlugin(var dispatchAt : Int,
           val onChunk = for(((cFrom, cTo), enable) <- rs.chunks.zip(rs.ENABLES)){
             for (writeEu <- eus if writeEu.getUopLayerSpec().flatMap(_.rd).map(_.rf).distinctLinked.intersect(rs.regFiles).nonEmpty) {
               val hazardRange = cFrom to (writeEu.getRdBroadcastedFromMax(rs.regFilesList) - 1 min cTo)
-              val offset = rs.chunks.head._1 - 1
+              val offset = cFrom - 1
               assert(hc.ll.lane.rfReadAt == 0, "else need less bypass at the end")
 //              println(s"${hc.ll.name} ${rs.self.getName()} ${writeEu.laneName} $hazardRange offset=$offset")
               for (id <- hazardRange) {

--- a/src/main/scala/vexiiriscv/schedule/DispatchPlugin.scala
+++ b/src/main/scala/vexiiriscv/schedule/DispatchPlugin.scala
@@ -265,7 +265,7 @@ class DispatchPlugin(var dispatchAt : Int,
           val hazards = ArrayBuffer[Bool]()
           val onChunk = for(((cFrom, cTo), enable) <- rs.chunks.zip(rs.ENABLES)){
             for (writeEu <- eus if writeEu.getUopLayerSpec().flatMap(_.rd).map(_.rf).distinctLinked.intersect(rs.regFiles).nonEmpty) {
-              val hazardRange = cFrom to (writeEu.getRdBroadcastedFromMax(rs.regFilesList) - 1 min cTo)
+              val hazardRange = cFrom until writeEu.getRdBroadcastedFromMax(rs.regFilesList)
               val offset = cFrom - 1
               assert(hc.ll.lane.rfReadAt == 0, "else need less bypass at the end")
 //              println(s"${hc.ll.name} ${rs.self.getName()} ${writeEu.laneName} $hazardRange offset=$offset")


### PR DESCRIPTION
I think the rs hazard logic use a wrong offset of lane ctrl.  For enables associated with different stages, the logic should always check read-after-write hazard from lane ctrl 1.